### PR TITLE
Add detail to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# cccl
-A Common Controller Core Library for orchestrating an F5 BIG-IP
+# Introduction
+
+This project implements a Common Controller Core Library for orchestration an F5 BIG-IP (r) for use within other libraries that need to read, diff and apply configurations to a BIG-IP (r).
+
+# Filling Issues
+
+Creating issues is good, creating good issues is even better. Please provide:
+* Clear steps on how to replicate the issue
+* Stack trace and error messages
+* SHA and branch information for f5-cccl
+* SHA and branch information for component using f5-cccl
+
+# Contributing
+
+This project is used internally by other F5 projects; we're not yet ready to accept contributions. Please check back later or see if another project, such as https://github.com/F5Networks/f5-common-python would be a good place for your contribution.
+
+# Copyright
+Copyright 2017 F5 Networks Inc.
+
+# License
+
+## Apache V2.0
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations
+under the License.


### PR DESCRIPTION
Fixes #3

Problem:
README.md needs to include Contributing, Copyright and License sections.

Analysis:
- Contributions section will guide folks to other repos for now since this is envisioned as an internal tool.
- Filling Issues section was added with detailed request of what to include since multiple teams/repos will depend on cccl

Solution:
Added necessary setions