### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 
 This project implements a Common Controller Core Library for orchestration an F5 BIG-IP (r) for use within other libraries that need to read, diff and apply configurations to a BIG-IP (r).
 
+# Installation
+Add f5-cccl to the `requirements.txt` file for your project. Use [editable package format](https://pip.readthedocs.io/en/stable/reference/pip_install/#git):
+```
+[-e] git+https://git.myproject.org/MyProject#egg=MyProject
+```
+
 # Filling Issues
 
 Creating issues is good, creating good issues is even better. Please provide:
+
 * Clear steps on how to replicate the issue
 * Stack trace and error messages
 * SHA and branch information for f5-cccl
@@ -25,7 +32,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the
 License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Problem:
Developers and users need to know how to install f5-cccl

Analysis:
While in beta, editable package format within `requirements.txt` provides the ablity to use f5-cccl in other projects. PyPI and other package distribution systems will be added as appropriate.

Solution:
Add instructions on how to use editable package format.