### PR TITLE
Fixes #13: Fixes .git-commit-template.txt

### DIFF
--- a/.git-commit-template.txt
+++ b/.git-commit-template.txt
@@ -1,8 +1,5 @@
-# Headline or summary  of the issue you are fixing
-
 # Using the Fixes #<issueid> will close the issue on commit to repo
-Issues:
-Fixes #<issueid>
+Fixes #<issueid>: <brief>
 
 # Describe the issue that this change addresses
 Problem:


### PR DESCRIPTION
Problem:
* Previous format was not brief enough

Solution:
* Put the brief/summary at the first line after Fixes

@andrewjjenkins @richbrowne 