### PR TITLE
Fixes #21: travis build broken in pre_install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
 before_install:
   - git config --global user.email "OpenStack_TravisCI@f5.com"
   - git config --global user.name "Travis F5 Openstack"
-  - git fetch --depth=100
 install:
   - pip install tox
   - pip install -r requirements.test.txt


### PR DESCRIPTION
Problem:
The git fetch --depth 100 is causing the failure.

Analysis:
Remove the command as it is not required at this time.

Tests:
Run travis build