### PR TITLE
Fixes #38: Add a Resource class to handle configuration changes.

### DIFF
--- a/f5_cccl/exceptions.py
+++ b/f5_cccl/exceptions.py
@@ -34,3 +34,27 @@ class F5CcclError(Exception):
             return "%s - %s" % (classname, self.msg)
         else:
             return classname
+
+
+class F5CcclResourceCreateError(F5CcclError):
+    u"""General resource creation failure."""
+
+
+class F5CcclResourceConflictError(F5CcclError):
+    u"""Resource already exists on BIG-IP?."""
+
+
+class F5CcclResourceNotFoundError(F5CcclError):
+    u"""Resource not found on BIG-IP?."""
+
+
+class F5CcclResourceRequestError(F5CcclError):
+    u"""Resource request client error on BIG-IP?."""
+
+
+class F5CcclResourceUpdateError(F5CcclError):
+    u"""General resource update failure."""
+
+
+class F5CcclResourceDeleteError(F5CcclError):
+    u"""General resource delete failure."""

--- a/f5_cccl/resource/__init__.py
+++ b/f5_cccl/resource/__init__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .resource import Resource  # noqa: F401, F403 pylint: disable=wildcard-import

--- a/f5_cccl/resource/resource.py
+++ b/f5_cccl/resource/resource.py
@@ -1,0 +1,196 @@
+u"""This module provides class for managing resource configuration."""
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.sdk_exception import F5SDKError
+import f5_cccl.exceptions as cccl_exc
+from icontrol.exceptions import iControlUnexpectedHTTPError
+
+
+class Resource(object):
+    u"""Resource super class to wrap BIG-IP? configuration objects.
+
+    A Resource represents a piece of CCCL configuration as represented
+    by the cccl-api-schema.  It's purpose is to wrap configuration into
+    an object that can later be used to perform Create, Read, Update,
+    and Delete operations on the BIG-IP?
+
+    Data should only be initialized on creation of the Resouce object
+    and not modified.  If a new representation is required a Resouce
+    object with the corrected model should be created and the original
+    discarded.
+
+    The subclasses of Resource should only concern themselves with
+    manipuation of the schema data to pack it into a payload that
+    can be used to perform create, modify, and delete operations.
+    Therefore, it is expected that the specialization of subclasses will
+    be concentrated in the __init__, update, and __eq__ methodss.
+
+    All subclasses are expected to implement the _uri_path method so
+    that the appropriate resource URI is used when performing CRUD.
+
+    """
+
+    def __init__(self, data):
+        u"""Initialize a BIG-IP? resource object from a CCCL schema object."""
+        self._data = data
+        self._name = data.get('name', None)
+        self._partition = data.get('partition', None)
+
+    def create(self, bigip):
+        u"""Create resource on a BIG-IP® system.
+
+        The internal data model is applied to the BIG-IP?
+
+        Args:
+            bigip (f5.bigip.ManagementRoot): F5 SDK session object
+
+        Returns: created resource object.
+
+        Raises:
+            F5CcclResourceCreateError: resouce cannot be created for an
+            unspecified reason.
+
+            F5CcclResourceConflictError: resouce cannot be created because
+            it already exists on the BIG-IP?
+        """
+        try:
+            obj = self._uri_path(bigip).create(**self._data)
+            return obj
+        except iControlUnexpectedHTTPError as err:
+            self._handle_http_error(err)
+        except F5SDKError as err:
+            raise cccl_exc.F5CcclResourceCreateError(str(err))
+
+    def read(self, bigip):
+        u"""Retrieve a BIG-IP® resource from a BIG-IP®.
+
+        Returns a resource object with attributes for instance on a
+        BIG-IP® system.
+
+        Args:
+            bigip (f5.bigip.ManagementRoot): F5 SDK session object
+
+        Returns: resource retrieved from BIG-IP?
+
+        Raises:
+            F5CcclResourceNotFoundError: resouce cannot be loaded because
+            it does not exist on the BIG-IP?
+        """
+        try:
+            obj = self._uri_path(bigip).load(
+                name=self._name,
+                partition=self._partition)
+            return obj
+        except iControlUnexpectedHTTPError as err:
+            self._handle_http_error(err)
+        except F5SDKError as err:
+            raise cccl_exc.F5CcclError(str(err))
+
+    def update(self, bigip):
+        u"""Update a resource (e.g., pool) on a BIG-IP® system.
+
+        Modifies a resource on a BIG-IP® system using attributes
+        defined in the model object.
+        The internal data model is applied to the BIG-IP?
+
+        Args:
+            bigip: BigIP instance to use for updating resource.
+
+        Raises:
+            F5CcclResourceUpdateError: resouce cannot be updated for an
+            unspecified reason.
+
+            F5CcclResourceNotFoundError: resouce cannot be updated because
+            it does not exist on the BIG-IP?
+        """
+        try:
+            obj = self._uri_path(bigip).load(
+                name=self._name,
+                partition=self._partition)
+            obj.modify(**self._data)
+        except iControlUnexpectedHTTPError as err:
+            self._handle_http_error(err)
+        except F5SDKError as err:
+            raise cccl_exc.F5CcclResourceUpdateError(str(err))
+
+    def delete(self, bigip):
+        u"""Delete a resource on a BIG-IP® system.
+
+        Loads a resource and deletes it.
+
+        Args:
+            bigip: BigIP instance to use for delete resource.
+
+        Raises:
+            F5CcclResourceDeleteError: resouce cannot be deleted for an
+            unspecified reason.
+
+            F5CcclResourceNotFoundError: resouce cannot be deleted because
+            it already exists on the BIG-IP?
+        """
+        try:
+            obj = self._uri_path(bigip).load(
+                name=self._name,
+                partition=self._partition)
+            obj.delete()
+        except iControlUnexpectedHTTPError as err:
+            self._handle_http_error(err)
+        except F5SDKError as err:
+            raise cccl_exc.F5CcclResourceDeleteError(str(err))
+
+    @property
+    def name(self):
+        u"""Get the name for this resource."""
+        return self._name
+
+    @property
+    def partition(self):
+        u"""Get the partition for this resource."""
+        return self._partition
+
+    @property
+    def data(self):
+        u"""Get the internal data model for this resource."""
+        return self._data
+
+    def _uri_path(self, bigip):
+        u"""Get the URI resource path key for the F5 SDK.
+
+        For example, a pool resource returns:
+
+        bigip.tm.ltm.pools.pool
+
+        This needs to be implemented by a Resouce subclass.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def _handle_http_error(error):
+        u"""Extract the error code and reraise a CCCL Error."""
+        code = error.response.status_code
+        if code == 404:
+            raise cccl_exc.F5CcclResourceNotFoundError(
+                error.response.message)
+        elif code == 409:
+            raise cccl_exc.F5CcclResourceConflictError(
+                error.response.message)
+        elif code >= 400 and code < 500:
+            raise cccl_exc.F5CcclResourceRequestError(
+                error.response.message)
+        else:
+            raise cccl_exc.F5CcclError(error.response.message)

--- a/f5_cccl/resource/test/test_resource.py
+++ b/f5_cccl/resource/test/test_resource.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.sdk_exception import F5SDKError
+import f5_cccl.exceptions as cccl_exc
+from f5_cccl.resource import Resource
+
+from icontrol.exceptions import iControlUnexpectedHTTPError
+from mock import MagicMock
+import pytest
+
+
+def resource_data():
+    return {'name': "test_resource", 'partition': "Common"}
+
+
+@pytest.fixture
+def bigip():
+    bigip = MagicMock()
+    bigip.tm.ltm.subresources.subresource = MagicMock()
+
+    return bigip
+
+
+@pytest.fixture
+def response():
+    response = MagicMock()
+    response.message = "Mock response"
+
+    return response
+
+
+class SubResource(Resource):
+
+    def __init__(self, data):
+        super(SubResource, self).__init__(data)
+
+    def _uri_path(self, bigip):
+        return bigip.tm.ltm.subresources.subresource
+
+
+def test_create_resource_with_data():
+    u"""Test Resource instantiation with data."""
+    data = resource_data()
+    name = data.get('name', "")
+    partition = data.get('partition', "")
+
+    res = Resource(data)
+
+    assert res
+    assert res.name == name
+    assert res.partition == partition
+    assert res.data
+
+
+def test_create_resource_without_data():
+    u"""Test Resource instantiation without data."""
+    res = Resource(data={})
+
+    assert res
+    assert not res.name
+    assert not res.partition
+    assert not res.data
+
+
+def test_get_uri_path(bigip):
+    u"""Test _uri_path throws NotImplemented."""
+    res = Resource(data={})
+
+    with pytest.raises(NotImplementedError):
+        res._uri_path(bigip)
+
+
+def test_create_resource(bigip):
+    u"""Test Resource creation."""
+    data = resource_data()
+
+    res = Resource(data)
+
+    with pytest.raises(NotImplementedError):
+        res.create(bigip)
+
+
+def test_delete_resource(bigip):
+    u"""Test Resource delete."""
+    data = resource_data()
+
+    res = Resource(data)
+
+    with pytest.raises(NotImplementedError):
+        res.delete(bigip)
+
+
+def test_read_resource(bigip):
+    u"""Test Resource read."""
+    data = resource_data()
+
+    res = Resource(data)
+
+    with pytest.raises(NotImplementedError):
+        res.read(bigip)
+
+
+def test_update_resource(bigip):
+    u"""Test Resource update."""
+    data = resource_data()
+
+    res = Resource(data)
+
+    with pytest.raises(NotImplementedError):
+        res.update(bigip)
+
+
+def test_set_name():
+    u"""Test Resource name update."""
+    data = resource_data()
+
+    res = Resource(data)
+
+    with pytest.raises(AttributeError):
+        res.name = "test_resource"
+
+
+def test_set_partition():
+    u"""Test Resource partition update."""
+    data = resource_data()
+
+    res = Resource(data)
+
+    with pytest.raises(AttributeError):
+        res.partition = "Common"
+
+
+def test_set_data():
+    u"""Test Resource data update."""
+    data = resource_data()
+
+    res = Resource(data)
+
+    with pytest.raises(AttributeError):
+        res.data = {}
+
+
+def test_create_subresource(bigip):
+    u"""Test that a subclass of Resource will execute 'create'."""
+    data = resource_data()
+    subres = SubResource(data)
+
+    bigip.tm.ltm.subresources.subresource.create.return_value = (
+        bigip.tm.ltm.subresources.subresource)
+
+    obj = subres.create(bigip)
+
+    assert obj == bigip.tm.ltm.subresources.subresource
+
+    bigip.tm.ltm.subresources.subresource.create.assert_called()
+
+
+def test_update_subresource(bigip):
+    u"""Test that a subclass of Resource will execute 'update'."""
+    data = resource_data()
+    subres = SubResource(data)
+
+    bigip.tm.ltm.subresources.subresource.modify.return_value = (None)
+    bigip.tm.ltm.subresources.subresource.load.return_value = (
+        bigip.tm.ltm.subresources.subresource.obj
+    )
+    obj = subres.update(bigip)
+
+    assert not obj
+    bigip.tm.ltm.subresources.subresource.load.assert_called()
+    bigip.tm.ltm.subresources.subresource.obj.modify.assert_called()
+
+
+def test_delete_subresource(bigip):
+    u"""Test that a subclass of Resource will execute 'delete'."""
+    data = resource_data()
+    subres = SubResource(data)
+
+    bigip.tm.ltm.subresources.subresource.load.return_value = (
+        bigip.tm.ltm.subresources.subresource.obj
+    )
+
+    subres.delete(bigip)
+
+    bigip.tm.ltm.subresources.subresource.load.assert_called()
+    bigip.tm.ltm.subresources.subresource.obj.delete.assert_called()
+
+
+def test_create_subresource_sdk_exception(bigip):
+    u"""Test create can handle SDK exception."""
+    data = resource_data()
+    subres = SubResource(data)
+    bigip.tm.ltm.subresources.subresource.create.side_effect = (
+        [F5SDKError, None]
+    )
+
+    with pytest.raises(cccl_exc.F5CcclResourceCreateError):
+        obj = subres.create(bigip)
+
+        assert not obj
+
+
+def test_create_subresource_icontrol_409_exception(bigip, response):
+    u"""Test create can handle HTTP 409 exception."""
+    data = resource_data()
+    subres = SubResource(data)
+
+    response.status_code = 409
+    bigip.tm.ltm.subresources.subresource.create.side_effect = (
+        [iControlUnexpectedHTTPError(response=response), None]
+    )
+
+    with pytest.raises(cccl_exc.F5CcclResourceConflictError):
+        obj = subres.create(bigip)
+
+        assert not obj
+
+
+def test_create_subresource_icontrol_4XX_exception(bigip, response):
+    u"""Test create can handle HTTP client exception."""
+    data = resource_data()
+    subres = SubResource(data)
+
+    response.status_code = 400
+    bigip.tm.ltm.subresources.subresource.create.side_effect = (
+        [iControlUnexpectedHTTPError(response=response), None]
+    )
+
+    with pytest.raises(cccl_exc.F5CcclError):
+        obj = subres.create(bigip)
+
+        assert not obj
+
+
+def test_create_subresource_icontrol_500_exception(bigip, response):
+    u"""Test create can handle HTTP server exception."""
+    data = resource_data()
+    subres = SubResource(data)
+
+    response.status_code = 500
+    bigip.tm.ltm.subresources.subresource.create.side_effect = (
+        [iControlUnexpectedHTTPError(response=response), None]
+    )
+
+    with pytest.raises(cccl_exc.F5CcclError):
+        obj = subres.create(bigip)
+
+        assert not obj
+
+
+def test_update_subresource_sdk_exception(bigip):
+    u"""Test update can handle SDK exception."""
+    data = resource_data()
+    subres = SubResource(data)
+
+    bigip.tm.ltm.subresources.subresource.load.return_value = (
+        bigip.tm.ltm.subresources.subresource
+    )
+    bigip.tm.ltm.subresources.subresource.modify.side_effect = (
+        [F5SDKError, None]
+    )
+
+    with pytest.raises(cccl_exc.F5CcclResourceUpdateError):
+        subres.update(bigip)
+
+
+def test_update_subresource_icontrol_404_exception(bigip, response):
+    u"""Test update can handle HTTP 404 not found exception.
+
+    A NotFound error should occur when the resource load is performed.
+    """
+    data = resource_data()
+    subres = SubResource(data)
+
+    response.status_code = 404
+
+    bigip.tm.ltm.subresources.subresource.load.side_effect = (
+        [iControlUnexpectedHTTPError(response=response), None]
+    )
+
+    with pytest.raises(cccl_exc.F5CcclResourceNotFoundError):
+        subres.update(bigip)
+
+    bigip.tm.ltm.subresources.subresource.modify.assert_not_called()
+
+
+def test_update_subresource_icontrol_4XX_exception(bigip, response):
+    u"""Test update can handle gener HTTP client request exception."""
+    data = resource_data()
+    subres = SubResource(data)
+
+    response.status_code = 400
+    bigip.tm.ltm.subresources.subresource.load.return_value = (
+        bigip.tm.ltm.subresources.subresource.obj
+    )
+    bigip.tm.ltm.subresources.subresource.obj.modify.side_effect = (
+        [iControlUnexpectedHTTPError(response=response), None]
+    )
+
+    with pytest.raises(cccl_exc.F5CcclResourceRequestError):
+        obj = subres.update(bigip)
+
+        assert not obj
+
+
+def test_delete_subresource_sdk_exception(bigip):
+    u"""Test update can handle SDK exception."""
+    data = resource_data()
+    subres = SubResource(data)
+
+    bigip.tm.ltm.subresources.subresource.load.return_value = (
+        bigip.tm.ltm.subresources.subresource
+    )
+    bigip.tm.ltm.subresources.subresource.delete.side_effect = (
+        [F5SDKError, None]
+    )
+
+    with pytest.raises(cccl_exc.F5CcclResourceDeleteError):
+        subres.delete(bigip)
+
+
+def test_delete_subresource_icontrol_404_exception(bigip, response):
+    u"""Test delete can handle HTTP 404 not found exception.
+
+    A NotFound error should occur when the resource load is performed.
+    """
+    data = resource_data()
+    subres = SubResource(data)
+
+    response.status_code = 404
+
+    bigip.tm.ltm.subresources.subresource.load.side_effect = (
+        [iControlUnexpectedHTTPError(response=response), None]
+    )
+
+    with pytest.raises(cccl_exc.F5CcclResourceNotFoundError):
+        subres.delete(bigip)
+
+    bigip.tm.ltm.subresources.subresource.delete.assert_not_called()
+
+
+def test_delete_subresource_icontrol_4XX_exception(bigip, response):
+    u"""Test delete can handle gener HTTP client request exception."""
+    data = resource_data()
+    subres = SubResource(data)
+
+    response.status_code = 400
+    bigip.tm.ltm.subresources.subresource.load.return_value = (
+        bigip.tm.ltm.subresources.subresource
+    )
+    bigip.tm.ltm.subresources.subresource.delete.side_effect = (
+        [iControlUnexpectedHTTPError(response=response), None]
+    )
+
+    with pytest.raises(cccl_exc.F5CcclResourceRequestError):
+        obj = subres.delete(bigip)
+
+        assert not obj

--- a/f5_cccl/test/test_exceptions.py
+++ b/f5_cccl/test/test_exceptions.py
@@ -44,3 +44,57 @@ def test_raise_f5ccclerror():
             raise exceptions.F5CcclError()
 
         f()
+
+
+def test_raise_f5cccl_resource_create_error():
+    """Test raising a F5CcclResourceCreateError."""
+    with pytest.raises(exceptions.F5CcclResourceCreateError):
+        def f():
+            raise exceptions.F5CcclResourceCreateError()
+
+        f()
+
+
+def test_raise_f5cccl_resource_conflict_error():
+    """Test raising a F5CcclConflictError."""
+    with pytest.raises(exceptions.F5CcclResourceConflictError):
+        def f():
+            raise exceptions.F5CcclResourceConflictError()
+
+        f()
+
+
+def test_raise_f5cccl_resource_notfound_error():
+    """Test raising a F5CcclResourceNotFoundError."""
+    with pytest.raises(exceptions.F5CcclResourceNotFoundError):
+        def f():
+            raise exceptions.F5CcclResourceNotFoundError()
+
+        f()
+
+
+def test_raise_f5cccl_resource_request_error():
+    """Test raising a F5CcclResourceRequestError."""
+    with pytest.raises(exceptions.F5CcclResourceRequestError):
+        def f():
+            raise exceptions.F5CcclResourceRequestError()
+
+        f()
+
+
+def test_raise_f5cccl_resource_update_error():
+    """Test raising a F5CcclResourceUpdateError."""
+    with pytest.raises(exceptions.F5CcclResourceUpdateError):
+        def f():
+            raise exceptions.F5CcclResourceUpdateError()
+
+        f()
+
+
+def test_raise_f5cccl_resource_delete_error():
+    """Test raising a F5CcclResourceDeleteError."""
+    with pytest.raises(exceptions.F5CcclResourceDeleteError):
+        def f():
+            raise exceptions.F5CcclResourceDeleteError()
+
+        f()


### PR DESCRIPTION
Problem:
The resources managed by CCCL (e.g. Virtuals, Pools, Healthmonitors,
Members, Nodes, Virtual Addresses) should have python object
representations to use to perform CRUD and compare the schema
config model with the existing config on the big-ip.

Analysis:
    Resource super class to wrap BIG-IP? configuration objects.

    A Resource represents a piece of CCCL configuration as represented
    by the cccl-api-schema.  It's purpose is to wrap configuration into
    an object that can later be used to perform Create, Read, Update,
    and Delete operations on the BIG-IP?

    Data should only be initialized on creation of the Resouce object
    and not modified.  If a new representation is required a Resouce
    object with the corrected model should be created and the original
    discarded.

    The subclasses of Resource should only concern themselves with
    manipuation of the schema data to pack it into a payload that
    can be used to perform create, modify, and delete operations.
    Therefore, it is expected that the specialization of subclasses will
    be concentrated in the __init__, update, and __eq__ methodss.

    All subclasses are expected to implement the _uri_path method so
    that the appropriate resource URI is used when performing CRUD.

Tests:
resource/test/test_resource.py
test/test_exceptions.py