### PR TITLE
Fixes #41 - Adds a new Resource sub-class Pool

### DIFF
--- a/f5_cccl/resource/ltm/pool.py
+++ b/f5_cccl/resource/ltm/pool.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+
+import f5_cccl.exceptions as exceptions
+
+from f5_cccl.resource import Resource
+
+logger = logging.getLogger(__name__)
+
+"""Hosts an interface for the BIG-IP Pool Resource.
+
+This module references and holds items relevant to the orchestration of the F5
+BIG-IP for purposes of abstracting the F5-SDK library.
+"""
+
+
+class Pool(Resource):
+    """Creates a CCCL BIG-IP Pool Object of sub-type of Resource
+
+This object hosts the ability to orchestrate basic CRUD actions against a
+BIG-IP Pool via the F5-SDK.
+    """
+    _data = dict()
+
+    def __dict__(self):
+        """Dictionary converter method"""
+        items = self._data
+        # FIXME: handle the monitor and members attributes individually here
+        return items
+
+    def __eq__(self, compare):
+        """Checks Equality between this CCCL Pool and another BIG-IP Pool
+
+        This method will transform the comparison into a relative dict of the
+        BIG-IP Pool properties addressed in CCCL's Pool and compare them.
+
+        This intentionally includes a shallow dict comparison of schema-based
+        attributes and a "left-to-the-member" comparison of pool members.  To
+        add more of these, simply add more attributes to the CCCL Pool object.
+
+        :param compare: [CCCL Pool object | dict(BIG-IP Pool Attributes)]
+        :returns: Bool [True:=Pools are equal, False:=Not Equal]
+
+        Use:
+            obj == compare or obj.equals(compare) or obj.__eq__(compare)
+        """
+        # get rid of the most obvious case first...
+        if not isinstance(compare, Pool) and not isinstance(compare, dict):
+            return False
+        comparison = extract_comparison(compare)
+        myself = self.__dict__(True)
+        # AssertionError is cycle-wise faster than if/then/else nests...
+        try:
+            self.__shallow_compare(myself, comparison)
+            self.__member_compare(myself, comparison)
+        except AssertionError as Err:
+            # We're NE, log a reason when troubleshooting this and move on
+            logger.debug(str(Err))  # this can get really noisy!
+            return False
+        except KeyError as Err:
+            logger.debug(str(Err))
+            return False
+        return True
+
+    def __init__(self, partition=None, description=None, name=None,
+                 members=None, monitor=None, loadBalancingMode=None,
+                 bigip=None):
+        """Init method"""
+        if not name or not partition:
+            raise exceptions.F5CcclResourceCreateError(
+                "Failed to create Pool due to missing requirement "
+                "name({}) partition({})".format(name, partition))
+        super(Pool, self).__init__(dict(name=name, partition=partition))
+        self._data['description'] = description
+        self._data['loadBalancingMode'] = loadBalancingMode
+        self._data['members'] = members
+        self._data['monitor'] = monitor
+
+    def __member_compare(self, myself, comparison):
+        """An internal Pool method"""
+        # This method compares two sets of members against one another
+        # :params: dict(members=<members>)
+        # :returns: Bool [True:=Equal,False:=Not Equal]
+        raise NotImplementedError("member handling not implemented yet")
+
+    def __shallow_compare(self, myself, comparison, stop=False):
+        """An internal Pool method"""
+        # This method compares two dicts at a very shallow level (first keys)
+        # :params: dict()
+        # :returns: Bool [True:=Equal,False:=Not Equal]
+        keys = list(self._data.keys())
+        keys.remove('members')
+        keys.remove('monitor')
+        for item in keys:
+            print(myself[item], comparison[item],
+                  myself[item] == comparison[item])
+            assert myself[item] == comparison[item], \
+                'Because {} attr is not equal'.format(item)
+
+    def __str__(self):
+        """Str conversion method"""
+        return "Pool(name={}, description={}, loadBalancingMode={})".format(
+            self.name, self.description, self.loadBalancingMode)
+
+    def create(self, bigip):
+        """Creates New Pool on the BIG-IP based upon this CCCL Pool
+
+        This method will store this CCCL Pool onto the BIG-IP by partition and
+        name.  If it already exists, then an exception is thrown.
+
+        :param new_pool: BIG-IP Pool item to be added to the partition
+        :return: NoDef
+        :exception: ResourceLtmCreationError - Could not create BIG-IP Pool
+        """
+        logger.debug("Attempting to create Pool(name={})".format(self.name))
+        return super(Pool, self).create(bigip)
+
+    def delete(self):
+        """Delete this CCCL Pool from the BIG-IP by partition and name
+
+        This method will attempt to delete this CCCL Pool from the BIG-IP via
+        the F5-SDK.  It will do this by this CCCL Pool's partition and name.
+
+        :params: None
+        :return: NoDef
+        """
+        logger.debug("Deleting {} Pool".format(self.name))
+        super(Pool, self).delete()
+
+    def read(self, bigip):
+        """Attempt to Retrieve this CCCL Pool from the BIG-IP
+
+        This method wraps the F5-SDK and returns the BIG-IP's stored Pool value
+        with this CCCL Pool's name and partition.
+
+        :params: None
+        :returns: BIG-IP Pool
+        """
+        logger.debug('Reading BIG-IP Pool {} from BIG-IP'.format(self.name))
+        return super(Pool, self).read(bigip)
+
+    def update(self, bigip):
+        """Attempt to Update the BIG-IP with this CCCL Pool
+
+        This method will take in an F5-SDK BIG-IP object and attempt to update
+        the pool on the BIG-IP.
+
+        :param bigip: F5-SDK BigIP object
+        :returns: None
+        """
+        logger.debug('Update BIG-IP Pool {}'.format(self.name))
+        super(Pool, self).update(bigip)
+
+    def equals(self, pool_diff):
+        """Compares 2 BIG-IP Pools.
+
+        Takes a BIG-IP Pool and compares it against this CCCL Pool and returns
+        a True/False on whether they are both equal to one another.
+
+        :return: Bool := [True: The Two instances are equal,
+                          False: They are not]
+        """
+        return self.__eq__(pool_diff)
+
+    def member_list(self):
+        """Returns the list of PoolMembers off of this CCCL Pool
+
+        This method will return the list of PoolMembers on this CCCL Pool.
+
+        NOTE: PoolMember instances will be returned in no specific order.
+
+        :returns: [BIG-IP Members] |- List of BIG-IP Members
+        """
+        return self.members
+
+    def add_member(self, member):
+        """Adds a Single PoolMember to the CCCL Pool
+
+        This method will add a BIG-IP PoolMember to this CCCL Pool.
+
+        :param member: PoolMember instance to be added
+        :return: None
+        """
+        logger.debug("Attemmping to add Member {} to Pool {}".format(
+                     self, member))
+        raise NotImplementedError("Member actions have not been implemented")
+
+    def read_member(self, name):
+        """Reads in a Single BIG-IP Member that exists in this BIG-IP Pool
+
+        This method will take in a name of a BIG-IP Member and return that
+        Member as a PoolMember if it exists in this BIG-IP Pool by partition
+        and name.  If it does not exist, then an exception is thrown.
+
+        :param name: The name of the BIG-IP Member
+        :return: PoolMember - the member whose name was given
+        :exception: MissingResourceError - No BIG-IP Member with this name
+        """
+        logger.debug(
+            "Attemping to read a BIG-IP Member {} from Pool {}".format(
+                    name, self))
+        raise NotImplementedError("member actions have not been implemented")
+
+    def remove_member(self, name):
+        """Removes a BIG Member from the BIG-IP Pool by name
+
+        This method will take in a name of a BIG-IP Member and remove it from
+        the CCCL Pool.  If the Member does not exist on the CCCL Pool, then an
+        exception will be thrown.
+
+        :param name: The name of the Member referenced
+        :returns: None
+        :exception: MissingResourceError - No member with the name exists in
+            the list of PoolMembers
+        """
+        logger.debug(
+            "Attemping to remove a BIG-IP Member {} from Pool {}".format(
+                    name, self))
+        raise NotImplementedError("member actions have not been implemented")
+
+    def find_member(self, name):
+        """Searches the Pool for the BIG-IP Member Referenced by Name
+
+        This method will return a True|False result on whether or not a BIG-IP
+        member exists on the BIG-IP Pool.
+
+        :param name: str The name of the BIG-IP Member
+        :returns: Bool := [True: BIG-IP Member exists on this CCCL Pool
+                           False: It does not]
+        """
+        logger.debug(
+            "Attemping to find a BIG-IP Member {} from Pool {}".format(
+                    name, self))
+        raise NotImplementedError("member actions have not been implemented")
+
+    @property
+    def description(self):
+        return self._data['description']
+
+    @property
+    def loadBalancingMode(self):
+        return self._data['loadBalancingMode']
+
+    @property
+    def members(self):
+        return self._data['members']
+
+    @property
+    def monitor(self):
+        return self._data['monitor']
+
+
+def extract_comparison(compare):
+    """Digests and Transforms a Pool.__dict__() Comparible Form
+
+    This method will return a CCCL Pool-comparible object regardless as to
+    whether it comes from the BIG-IP via the SDK or an approved schema.
+
+    :param compare: [CCCL Pool or BIG-IP Pool from the F5-SDK]
+    :returns: comparison - a dict() that is comparible to a Pool() instance
+    """
+    if isinstance(compare, Pool):
+        comparison = compare.__dict__()
+    elif isinstance(compare, dict):
+        comparison = compare
+        if isinstance(comparison['members'], list):
+            # Transform the list into the expected dict() format
+            transformation = dict()
+            for member in comparison['members']:
+                if isinstance(member, dict):
+                    transformation[member['name']] = member
+                else:
+                    # FIXME: This should include the PoolMember case
+                    raise NotImplementedError(
+                        "Cannot handle a member of type {} yet".format(
+                            type(member)))
+            comparison['members'] = transformation
+        elif isinstance(comparison['members'], dict):
+            pass
+        else:
+            # FIXME: this should be striped beteween a reference and a list
+            # case...
+            raise NotImplementedError(
+                "Unable to handle members of type {}".format(
+                    type(comparison['members'])))
+    return comparison

--- a/f5_cccl/resource/ltm/test/conftest.py
+++ b/f5_cccl/resource/ltm/test/conftest.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from mock import Mock
+from mock import patch
+
+
+class TestLtmResource(object):
+    """Creates a TestLtmResource Object
+
+This object is useful in inheriting it within other, branching
+Resource's sub-objects' testing.  This object uses built-in features that can
+be used by any number of Resource objects for their testing.
+    """
+    @pytest.fixture
+    def create_ltm_resource(self):
+        """Useful for mocking f5_cccl.resource.Resource.__init__()
+
+This test-class method is useful for mocking out the Resource parent object.
+        """
+        Resource = Mock()
+        # future proofing:
+        with patch('f5_cccl.resource.Resource.__init__', Resource,
+                   create=True):
+            self.create_child()

--- a/f5_cccl/resource/ltm/test/test_pool.py
+++ b/f5_cccl/resource/ltm/test/test_pool.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+from mock import Mock
+from mock import patch
+
+import conftest
+import f5_cccl.exceptions as exceptions
+import f5_cccl.resource.ltm.pool as target
+
+
+class Test_Pool(conftest.TestLtmResource):
+    store_logger = target.logger
+
+    # Fixtures and environment setups
+    def create_child(self):
+        """Creates a child by mocking the parent's __init__() method
+
+        This utilizes the conftest.TestLtmResource class's create_ltm_resource
+        method in the assistance of creating a child without the parent
+        running its __init__.
+        """
+        mock_name = Mock()
+        mock_partition = Mock()
+        args = \
+            dict(description='description',
+                 loadBalancingMode='loadBalancingMode', members='members',
+                 monitor='monitor', name=mock_name, partition=mock_partition)
+        self.pool = target.Pool(**args)
+        self.pool._name = mock_name
+        self.pool._partition = mock_partition
+        self.args = args
+
+    # .conftest.TestLtmResource.create_ltm_resource
+    @pytest.fixture(autouse=True)
+    def create_pool(self, create_ltm_resource):
+        """Creates a child via mocking the parent and customization
+
+        This test fixture will create a child via conftest.TestLtmResource and
+        self.create_child().  Then customization can be performed to better
+        handle the using tests.
+        """
+        self.create_ltm_resource()
+
+    @pytest.fixture(autouse=True)
+    def mock_logger(self, request):
+        """Creates a Mock() instance for test target's logger object"""
+        request.addfinalizer(self.restore_logger)
+        self.logger = Mock()
+        target.logger = self.logger
+
+    def negative_init_case(self, **kwargs):
+        args = self.args
+        args.update(kwargs)
+        mock_parent = Mock()
+        with patch('f5_cccl.resource.Resource.__init__', mock_parent,
+                   create=True):
+            with pytest.raises(exceptions.F5CcclResourceCreateError):
+                print(args)
+                target.Pool(**args)
+
+    def restore_logger(self):
+        """Restores logger as per mock_logger() method"""
+        target.logger = self.store_logger
+
+    def not_implemented(self, method, *args):
+        with pytest.raises(NotImplementedError):
+            if args:
+                method(*args)
+            else:
+                method()
+
+    def test__eq__(self, mock_logger):
+        myself = 'myself'
+        comparison = 'comparison'
+        call_with = [myself, comparison]
+        mock_extract_comparison = Mock(
+            side_effect=[comparison, comparison, comparison, comparison,
+                         comparison, NotImplementedError])
+        self.pool._Pool__shallow_compare = Mock(side_effect=[
+                                                None, None, AssertionError,
+                                                None, NotImplementedError])
+        self.pool._Pool__member_compare = Mock(side_effect=[
+                                               None, None, AssertionError,
+                                               NotImplementedError])
+        self.pool.__dict__ = Mock(return_value=myself)
+        with patch('f5_cccl.resource.ltm.pool.extract_comparison',
+                   mock_extract_comparison, create=True):
+            assert self.pool == self.pool, "Positive Pool test"
+            self.pool._Pool__shallow_compare.assert_called_once_with(
+                *call_with)
+            self.pool._Pool__member_compare.assert_called_once_with(*call_with)
+            assert self.pool == dict(), 'Positive dict test'
+            assert not self.pool == dict(), 'Negative member compare'
+            assert not self.pool == dict(), 'Negative shallow compare'
+            for cnt in range(2):
+                with pytest.raises(NotImplementedError):
+                    self.pool == dict()
+
+    def test__dict__(self):
+        result = self.pool.__dict__()
+        args = self.args
+
+        # parent should handle...
+        args.pop('name')
+        args.pop('partition')
+
+        # perform our tests...
+        assert result == self.args, "positive test"
+
+    def test__init__(self):
+        """Tests the target's __init__ method"""
+        for arg in self.args:
+            if arg == 'name' or arg == 'partition':
+                # parent should test this...
+                continue
+            assert getattr(self.pool, arg, None) == arg
+        # negative case, missing either name or partition
+        self.negative_init_case(name='present', partition=None)
+        self.negative_init_case(partition='present', name=None)
+
+    def test_add_member(self):
+        self.not_implemented(self.pool.add_member, 'member')
+
+    def test_create(self):
+        """tests the appropriate creation of a f5_cccl.resource.ltm.pool.Pool
+
+        This test is heavily dependent on fixtures in this repo and in conftest
+        and only tests the positive case.
+        """
+        expected = 'expected'
+        assert expected == self.with_mocking_super_methods(
+            self.pool.create, 'f5_cccl.resource.Resource.create',
+            expected=expected, arg='bigip'), "Positive Return Case"
+
+    def test_delete(self, mock_logger):
+        """Tests the target's delete method"""
+        assert not self.with_mocking_super_methods(
+            self.pool.delete,
+            'f5_cccl.resource.Resource.delete'), 'Positive Return Case'
+
+    def test_equals(self):
+        """Test target's equals method
+
+        This validates the case of a list of members and a string of monitors
+        along with the rest of the schema.
+        """
+        comparison = 'comaprison'
+        self.pool.__eq__ = Mock(side_effect=[True, False])
+        assert self.pool.equals(comparison), "Positive case test"
+        assert not self.pool.equals(comparison), "Negative case test"
+
+    def test_find_member(self):
+        self.not_implemented(self.pool.find_member, 'member')
+
+    def test_member_list(self):
+        """Tests target's member_list method
+
+        This is a fairly unique method to Pool.  This test method will test the
+        retrieval method of a list of members.
+        """
+        expected = self.pool._data['members']
+        assert expected == self.pool.member_list(), \
+            "There should be no difference here..."
+
+    def test__member_compare(self):
+        self.not_implemented(self.pool._Pool__member_compare,
+                             'myself', 'compare')
+
+    def test_properties(self):
+        for arg in self.args:
+            assert getattr(self.pool, arg, None) == self.args[arg], \
+                "{} property test".format(arg)
+
+    def test_read(self, mock_logger):
+        """Tests the target's read method"""
+        expected = 'expected'
+        bigip = 'bigip'
+        assert self.with_mocking_super_methods(
+            self.pool.read, 'f5_cccl.resource.Resource.read', expected,
+            bigip) == expected, "Positive return case"
+
+    def test_read_member(self):
+        self.not_implemented(self.pool.read_member, 'member')
+
+    def test__shallow_compare(self):
+        # positive case:
+        # dict().copy avoided for a reason...
+        baseline = self.pool._data.copy()
+        negative_missing_key = baseline.copy()
+        negative_changed_attr = baseline.copy()
+        positive_match = baseline.copy()
+        negative_missing_key.pop('description')
+        negative_changed_attr['description'] = 'will never be me'
+        self.pool._Pool__shallow_compare(baseline, positive_match)
+        with pytest.raises(KeyError):
+            self.pool._Pool__shallow_compare(baseline, negative_missing_key)
+        with pytest.raises(AssertionError):
+            self.pool._Pool__shallow_compare(baseline, negative_changed_attr)
+
+    def test_update(self):
+        """Tests 2 cases: when there's a difference and where is not"""
+        bigip = 'bigip'
+        assert not self.with_mocking_super_methods(
+            self.pool.update, 'f5_cccl.resource.Resource.update',
+            arg=bigip), "Positive return case"
+
+    def update_difference_case(self, data=None, p_id=Mock(), poolp=Mock(),
+                               partition=Mock()):
+        """Tests the need for an update
+
+        This is not a test, but it does suppliment test_update
+        """
+        pass
+
+    def update_no_difference_case(self, data=None, p_id=Mock(), poolp=Mock(),
+                                  partition=Mock()):
+        """Tests the case for no need to update
+
+        This is not a test, but it does assist test_update.
+        """
+        pass
+
+    def with_mocking_super_methods(
+                self, method, mock_case, expected=None, arg=None):
+        """Performs the testing steps for create() and delete()"""
+        positive_return_value = 'positive_return_value'
+        mock_parent = Mock(
+            side_effect=[expected, exceptions.F5CcclResourceNotFoundError])
+        with patch(mock_case, mock_parent,
+                   create=True):
+
+            # Positive case:
+            if arg:
+                positive_return_value = method(arg)
+            else:
+                positive_return_value = method()
+            if arg:
+                mock_parent.assert_called_once_with(arg)
+            else:
+                mock_parent.assert_called_once_with()
+
+            # Negative case:
+            with pytest.raises(exceptions.F5CcclResourceNotFoundError):
+                if arg:
+                    method(arg)
+                else:
+                    method()
+        return positive_return_value
+
+
+def test_extract_comparison():
+    compare_pool = target.Pool(name='name', partition='partition')
+    # Test pool case:
+    assert target.extract_comparison(compare_pool) == \
+        compare_pool.__dict__()
+    # dict cases:
+    cases = [dict(name='List of members=dict',
+                  comparison=dict(members=[dict(name='foo')], name='foo'),
+                  expected=dict(members=dict(foo=dict(name='foo')),
+                                name='foo')),
+             dict(name='dict of members',
+                  comparison=dict(members=dict(), name='foo'),
+                  expected='self'),
+             dict(name='NotImplemented members type',
+                  comparison=dict(members=str(), name='foo'),
+                  expected=NotImplementedError),
+             dict(name='NotImplemented member type',
+                  comparison=dict(members=[str()], name='foo'),
+                  expected=NotImplementedError)]
+    for case in cases:
+        name = case['name']
+        comparison = case['comparison']
+        expected = case['comparison'] if case['expected'] == 'self' else \
+            case['expected']
+        if isinstance(expected, type):
+            with pytest.raises(expected):
+                target.extract_comparison(comparison)
+        else:
+            result = target.extract_comparison(comparison)
+            assert result == expected, name

--- a/f5_cccl/resource/resource.py
+++ b/f5_cccl/resource/resource.py
@@ -1,5 +1,7 @@
-u"""This module provides class for managing resource configuration."""
 # coding=utf-8
+# vim: set fileencoding=utf-8
+# -*- coding: utf-8 -*-
+u"""This module provides class for managing resource configuration."""
 #
 # Copyright 2017 F5 Networks Inc.
 #


### PR DESCRIPTION
Fixes #41

Problem:
* There is no BIG-IP® Pool object handler for F5-CCCL's Resource
* There must be a sub-class for Resource to handle any Pools

Analysis:
* Created a Pool object as per specifics in the github issue

Tests:
* ./f5-cccl/f5_cccl/resource/ltm/tests/test_pool.py
 * Depends on
  * ./f5-cccl/f5_cccl/resource/tlm/tests/conftest.py
 * Coverage is 100% for current functionality