### PR TITLE
Validate the SchemaValidator

### DIFF
--- a/f5_cccl/service/test/test_schema_validator.py
+++ b/f5_cccl/service/test/test_schema_validator.py
@@ -57,7 +57,7 @@ def validate_defaults(validator, schema, services, rsc_type, rscs):
 
     # Go through the schema, find the 'default' fields, and verify that the
     # validator has added the defaults
-    for key, value in properties.iteritems():
+    for key, value in properties.items():
         default = value.get('default')
         if default is not None:
             for idx, rsc in enumerate(services[rscs]):
@@ -133,7 +133,7 @@ def validate_types(validator, schema, services, rsc_type, rscs):
     # Go through the schema; find the strings, integers, and enums and
     # change them to invalid values and verify that the validator catches
     # the errors
-    for key, value in properties.iteritems():
+    for key, value in properties.items():
         val_type = value.get('type')
         if val_type is not None:
             for idx, rsc in enumerate(services[rscs]):
@@ -179,7 +179,7 @@ def test_resources():
     # - catches missing required fields
     # - supplies correct defaults
     # - catches invalid parameter values and types
-    for key, value in resources.iteritems():
+    for key, value in resources.items():
         validate_required(validator, schema, services, key, value)
         validate_defaults(validator, schema, services, key, value)
         validate_types(validator, schema, services, key, value)

--- a/f5_cccl/service/test/test_schema_validator.py
+++ b/f5_cccl/service/test/test_schema_validator.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import f5_cccl.service.validation as validation
+import f5_cccl.exceptions as cccl_exc
+import json
+import jsonschema
+
+
+def validate(validator, services):
+    """Wrapper for validation of a service description."""
+    try:
+        validator.validate(services)
+        return 'Schema Valid'
+    except jsonschema.exceptions.SchemaError:
+        return 'Schema Error'
+    except cccl_exc.ValidationError:
+        return 'Validator Error'
+
+
+def validate_required(validator, schema, services, rsc_type, rscs):
+    """Validate required values."""
+    required = schema['definitions'][rsc_type]['required']
+
+    # Go through the schema, find the 'required' fields, remove them and
+    # verify that the validator catches the error
+    for req in required:
+        for idx, rsc in enumerate(services[rscs]):
+            tmp = rsc[req]
+            # delete it
+            del rsc[req]
+            services[rscs][idx] = rsc
+
+            # Required field is missing, should be an error
+            result = validate(validator, services)
+            assert result == 'Validator Error'
+
+            rsc[req] = tmp
+            services[rscs][idx] = rsc
+
+
+def validate_defaults(validator, schema, services, rsc_type, rscs):
+    """Validate default values."""
+    properties = schema['definitions'][rsc_type]['properties']
+
+    # Go through the schema, find the 'default' fields, and verify that the
+    # validator has added the defaults
+    for key, value in properties.iteritems():
+        default = value.get('default')
+        if default is not None:
+            for idx, rsc in enumerate(services[rscs]):
+                assert rsc[key] == default
+
+
+def validate_string(validator, schema, services, rsc, key, prop):
+    """Validate a string property."""
+    tmp = rsc.get(key)
+    if tmp is not None:
+        # not a string, validation should fail
+        rsc[key] = 100
+        result = validate(validator, services)
+        assert result == 'Validator Error'
+        rsc[key] = tmp
+
+    minLength = prop.get('minLength')
+    if minLength is not None and minLength > 0:
+        tmp = rsc.get(key)
+        if tmp is not None:
+            # less than min length, validation should fail
+            rsc[key] = ''
+            result = validate(validator, services)
+            assert result == 'Validator Error'
+            rsc[key] = tmp
+
+    maxLength = prop.get('maxLength')
+    if maxLength is not None:
+        tmp = rsc.get(key)
+        if tmp is not None:
+            # greater than max length, validation should fail
+            rsc[key] = 'x' * (maxLength + 1)
+            result = validate(validator, services)
+            assert result == 'Validator Error'
+            rsc[key] = tmp
+
+
+def validate_integer(validator, schema, services, rsc, key, prop):
+    """Validate an integer property."""
+    tmp = rsc.get(key)
+    if tmp is not None:
+        # not an integer, validation should fail
+        rsc[key] = 'This is not a number!'
+        result = validate(validator, services)
+        assert result == 'Validator Error'
+        rsc[key] = tmp
+
+    minimum = prop.get('minimum')
+    if minimum is not None:
+        tmp = rsc.get(key)
+        if tmp is not None:
+            # less than min value, validation should fail
+            rsc[key] = minimum - 1
+            result = validate(validator, services)
+            assert result == 'Validator Error'
+            rsc[key] = tmp
+
+    maximum = prop.get('maximum')
+    if maximum is not None:
+        tmp = rsc.get(key)
+        if tmp is not None:
+            # greater than max value, validation should fail
+            rsc[key] = maximum + 1
+            result = validate(validator, services)
+            assert result == 'Validator Error'
+            rsc[key] = tmp
+
+
+def validate_types(validator, schema, services, rsc_type, rscs):
+    """Validate the basic types in the schema."""
+    properties = schema['definitions'][rsc_type]['properties']
+
+    # Go through the schema; find the strings, integers, and enums and
+    # change them to invalid values and verify that the validator catches
+    # the errors
+    for key, value in properties.iteritems():
+        val_type = value.get('type')
+        if val_type is not None:
+            for idx, rsc in enumerate(services[rscs]):
+                # check strings
+                if val_type == 'string':
+                    validate_string(validator, schema, services, rsc, key,
+                                    value)
+
+                # check integers
+                if val_type == 'integer':
+                    validate_integer(validator, schema, services, rsc, key,
+                                     value)
+
+                # check enums
+                enum = value.get('enum')
+                if enum is not None:
+                    tmp = rsc.get(key)
+                    if tmp is not None:
+                        rsc[key] = 'This string will match no enums'
+                        result = validate(validator, services)
+                        assert result == 'Validator Error'
+                        rsc[key] = tmp
+
+
+def test_resources():
+    """Load a service description and validate it with the schema."""
+    svcfile = 'schemas/tests/service.json'
+    services = json.loads(open(svcfile, 'r').read())
+
+    validator = validation.SchemaValidator()
+    result = validate(validator, services)
+    assert result == 'Schema Valid'
+
+    # validate these properties from the schema
+    resources = {'virtualServerType': 'virtualServers',
+                 'poolType': 'pools',
+                 'l7PolicyType': 'l7Policies',
+                 'healthMonitorType': 'monitors'}
+
+    schema = validation.read_yaml_or_json(validation.DEFAULT_SCHEMA)
+
+    # Test the validator and verify that it:
+    # - catches missing required fields
+    # - supplies correct defaults
+    # - catches invalid parameter values and types
+    for key, value in resources.iteritems():
+        validate_required(validator, schema, services, key, value)
+        validate_defaults(validator, schema, services, key, value)
+        validate_types(validator, schema, services, key, value)

--- a/f5_cccl/service/test/test_validation.py
+++ b/f5_cccl/service/test/test_validation.py
@@ -74,7 +74,7 @@ class TestSchemaValidator(object):
         self.validator.validate_properties = \
             Mock(return_value=[errors])
         default = dict(default='default')
-        properties.iteritems = Mock(return_value=[['item', default]])
+        properties.items = Mock(return_value=[['item', default]])
         result = set_defaults(validator, properties, instance, schema)
         assert errors in result, "Generator has our errors"
         self.validator.validate_properties.assert_called_once_with(

--- a/f5_cccl/service/validation.py
+++ b/f5_cccl/service/validation.py
@@ -67,7 +67,7 @@ class SchemaValidator(object):
 
     def __set_defaults(self, validator, properties, instance, schema):
         """Helper function to simply return when setting defaults."""
-        for item, subschema in properties.iteritems():
+        for item, subschema in properties.items():
             if "default" in subschema:
                 instance.setdefault(item, subschema["default"])
 

--- a/schemas/tests/service.json
+++ b/schemas/tests/service.json
@@ -15,8 +15,8 @@
       "pools": [
         { "name": "pool1",
           "members": [
-            {"ipAddress": "172.16.0.100", "port": 8080, "routeDomain": 0},
-            {"ipAddress": "172.16.0.101", "port": 8080, "routeDomain": 0}
+            {"address": "172.16.0.100", "port": 8080, "routeDomain": {"id": 0}},
+            {"address": "172.16.0.101", "port": 8080, "routeDomain": {"id": 0}}
           ],
           "monitors": [{ "refname":  "/Common/http"}]
         }


### PR DESCRIPTION
Problem:
Validate that the SchemaValidator itself functions correctly

Solution:
Test the validator against the schema to verify that it:
- Supplies correct default values
- Catches errors when required fields are missing
- Catches errors for invalid data types and ranges