### PR TITLE
Add pylint style checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,418 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS,_f5.py,common.py
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality. This option is deprecated
+# and it will be removed in Pylint 2.0.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+#
+# NOTE: best reference for these messages is here:
+# https://pylint.readthedocs.io/en/latest/reference_guide/features.html
+disable=locally-disabled,
+  no-self-use,
+  invalid-name,
+  attribute-defined-outside-init,
+  too-few-public-methods,
+  too-many-instance-attributes,
+  too-many-arguments,
+  too-many-public-methods
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]". This option is deprecated
+# and it will be removed in Pylint 2.0.
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,ip,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=(_+[a-zA-Z0-9]*?$)|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ install:
   - pip install -r requirements.docs.txt
   - python ./setup.py install
 script:
-  - tox -e flake
+  - tox -e style
   - tox -e unit
 before_deploy: PKG_VERSION=$(python -c "import f5; print(f5_cccl.__version__)")

--- a/f5_cccl/__init__.py
+++ b/f5_cccl/__init__.py
@@ -13,7 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""F5 Common Controller Core Library.
+
+This module implements a Common Controller Core Library for use within other
+libraries that need to read, diff and apply configurations to a BIG-IP.
+"""
 
 __version__ = '0.1.0'
 
-from .api import F5CloudServiceManager # noqa: F401, F403 pylint: disable=wildcard-import
+from .api import F5CloudServiceManager # noqa: F401, F403

--- a/f5_cccl/_f5.py
+++ b/f5_cccl/_f5.py
@@ -169,7 +169,7 @@ class CloudBigIP(BigIP):
             "observed-member",
             "ratio-least-connections-member",
             "ratio-session"
-            )
+        )
         # This currently hard codes what resources we care about until we
         # enable policy management.
         if manage_types is None:
@@ -880,6 +880,7 @@ class CloudBigIP(BigIP):
 
     def virtual_address_delete(self, partition, name):
         """Delete a Virtual Address.
+
         Args:
             partition: Partition name
             name: Name of the virtual address
@@ -1316,7 +1317,7 @@ class CloudBigIP(BigIP):
             variables=iapp_def['variables'],
             tables=iapp_def['tables'],
             **config['iapp']['options']
-            )
+        )
 
     def iapp_delete(self, partition, name):
         """Delete an iApp Application Service.
@@ -1348,7 +1349,7 @@ class CloudBigIP(BigIP):
             variables=iapp_def['variables'],
             tables=iapp_def['tables'],
             **config['iapp']['options']
-            )
+        )
 
     def get_iapp(self, partition, name):
         """Get an iApp Application Service object.
@@ -1360,7 +1361,7 @@ class CloudBigIP(BigIP):
         a = self.sys.application.services.service.load(
             name=urllib.quote(name),
             partition=partition
-            )
+        )
         return a
 
     def get_iapp_list(self, partition):

--- a/f5_cccl/api.py
+++ b/f5_cccl/api.py
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""F5 Common Controller Core Library to read, diff and apply BIG-IP config."""
 
 
 class F5CloudServiceManager(object):
-    """F5 Common Controller Cloud Service Management
+    """F5 Common Controller Cloud Service Management.
 
     The F5 Common Controller Core Library (CCCL) is an orchestration package
     that provides a declarative API for defining BIG-IP LTM services in
@@ -28,6 +29,7 @@ class F5CloudServiceManager(object):
     namespace qualifiers to allow it to uniquely identify the resources
     under its control.
     """
+
     def __init__(self, bigip, partition, prefix=None):
         """Initialize an instance of the F5 CCCL service manager.
 
@@ -40,7 +42,7 @@ class F5CloudServiceManager(object):
         self._partition = partition
         self._prefix = prefix
 
-    def apply_config(self, services):
+    def apply_config(self, services):  # pylint: disable=unused-argument
         """Apply service configurations to the BIG-IP partition.
 
         :param services: A serializable object that defines one or more
@@ -51,7 +53,7 @@ class F5CloudServiceManager(object):
         return True
 
     def get_status(self):
-        """Gets status for each service in the managed partition.
+        """Get status for each service in the managed partition.
 
         :return: A serializable object of the statuses of each managed
         resource.

--- a/f5_cccl/exceptions.py
+++ b/f5_cccl/exceptions.py
@@ -32,20 +32,23 @@ class F5CcclError(Exception):
         classname = self.__class__.__name__
         if self.msg:
             return "%s - %s" % (classname, self.msg)
-        else:
-            return classname
+        return classname
 
 
 class SchemaError(F5CcclError):
     """Error raised when base schema defining API is invalid."""
+
     def __init__(self, msg):
+        """Initialize with base schema invalid message."""
         super(SchemaError, self).__init__(msg)
         self.msg = 'Schema provided is invalid: ' + msg
 
 
 class ValidationError(F5CcclError):
     """Error raised when service config is invalid against the API schema."""
+
     def __init__(self, msg):
+        """Initialize with base config does not match schema message."""
         super(ValidationError, self).__init__(msg)
         self.msg = 'Service congifuration provided does not match schema: ' + \
             msg

--- a/f5_cccl/resource/__init__.py
+++ b/f5_cccl/resource/__init__.py
@@ -13,5 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""This module implements the F5 CCCL Resource super class."""
+
 
 from .resource import Resource  # noqa: F401, F403 pylint: disable=wildcard-import

--- a/f5_cccl/resource/resource.py
+++ b/f5_cccl/resource/resource.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-"""This module provides class for managing resource configuration."""
 #
 # Copyright 2017 F5 Networks Inc.
 #
@@ -15,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""This module implements the F5 CCCL Resource super class."""
+
 
 import copy
 

--- a/f5_cccl/testcommon.py
+++ b/f5_cccl/testcommon.py
@@ -26,7 +26,7 @@ import f5
 import icontrol
 
 
-class Pool():
+class Pool(object):
     """A mock BIG-IP Pool."""
 
     def __init__(self, name, **kwargs):
@@ -52,7 +52,7 @@ class Pool():
         pass
 
 
-class Member():
+class Member(object):
     """A mock BIG-IP Pool Member."""
 
     def __init__(self, name, **kwargs):
@@ -69,7 +69,7 @@ class Member():
         pass
 
 
-class Profiles():
+class Profiles(object):
     """A container of Virtual Server Profiles."""
 
     def __init__(self, **kwargs):
@@ -89,7 +89,7 @@ class Profiles():
         pass
 
 
-class ProfileSet():
+class ProfileSet(object):
     """A set of Virtual Server Profiles."""
 
     def __init__(self, **kwargs):
@@ -97,7 +97,7 @@ class ProfileSet():
         self.profiles = Profiles(**kwargs)
 
 
-class Virtual():
+class Virtual(object):
     """A mock BIG-IP Virtual Server."""
 
     def __init__(self, name, **kwargs):
@@ -131,7 +131,7 @@ class Virtual():
         pass
 
 
-class HealthCheck():
+class HealthCheck(object):
     """A mock BIG-IP Health Monitor."""
 
     def __init__(self, name, **kwargs):
@@ -151,7 +151,7 @@ class HealthCheck():
         pass
 
 
-class MockService():
+class MockService(object):
     """A mock Services service object."""
 
     def __init__(self):
@@ -168,7 +168,7 @@ class MockService():
         pass
 
 
-class MockServices():
+class MockServices(object):
     """A mock Application services object."""
 
     def __init__(self):
@@ -180,7 +180,7 @@ class MockServices():
         return []
 
 
-class MockApplication():
+class MockApplication(object):
     """A mock Sys application object."""
 
     def __init__(self):
@@ -188,18 +188,14 @@ class MockApplication():
         self.services = MockServices()
 
 
-class MockFolders():
+class MockFolders(object):
     """A mock Sys folders object."""
 
     def __init__(self):
         """Initialize the object."""
 
-    def get_collection():
-        """Get collection of partitions."""
-        pass
 
-
-class MockSys():
+class MockSys(object):
     """A mock BIG-IP sys object."""
 
     def __init__(self):
@@ -208,7 +204,7 @@ class MockSys():
         self.folders = MockFolders()
 
 
-class MockIapp():
+class MockIapp(object):
     """A mock BIG-IP iapp object."""
 
     def __init__(self, name=None, template=None, partition=None,
@@ -233,7 +229,7 @@ class MockIapp():
         pass
 
 
-class MockFolder():
+class MockFolder(object):
     """A mock BIG-IP folder object."""
 
     def __init__(self, name):
@@ -241,7 +237,7 @@ class MockFolder():
         self.name = name
 
 
-class MockHttp():
+class MockHttp(object):
     """A mock Https http object."""
 
     def __init__(self):
@@ -256,7 +252,7 @@ class MockHttp():
         pass
 
 
-class MockHttps():
+class MockHttps(object):
     """A mock Monitor https object."""
 
     def __init__(self):
@@ -268,7 +264,7 @@ class MockHttps():
         pass
 
 
-class MockTcp():
+class MockTcp(object):
     """A mock Tcps tcp object."""
 
     def __init__(self):
@@ -284,7 +280,7 @@ class MockTcp():
         pass
 
 
-class MockTcps():
+class MockTcps(object):
     """A mock Monitor tcps object."""
 
     def __init__(self):
@@ -296,7 +292,7 @@ class MockTcps():
         pass
 
 
-class MockMonitor():
+class MockMonitor(object):
     """A mock Ltm monitor object."""
 
     def __init__(self):
@@ -305,7 +301,7 @@ class MockMonitor():
         self.tcps = MockTcps()
 
 
-class MockVirtuals():
+class MockVirtuals(object):
     """A mock Ltm virtuals object."""
 
     def __init__(self):
@@ -313,7 +309,7 @@ class MockVirtuals():
         self.virtual = Virtual('test')
 
 
-class MockPools():
+class MockPools(object):
     """A mock Ltm pools object."""
 
     def __init__(self):
@@ -325,7 +321,7 @@ class MockPools():
         pass
 
 
-class MockLtm():
+class MockLtm(object):
     """A mock BIG-IP ltm object."""
 
     def __init__(self):
@@ -335,7 +331,7 @@ class MockLtm():
         self.pools = MockPools()
 
 
-class MockHealthMonitor():
+class MockHealthMonitor(object):
     """A mock BIG-IP healthmonitor object."""
 
     def __init__(self, name, partition):
@@ -358,14 +354,14 @@ class BigIPTest(unittest.TestCase):
     members = {}
     healthchecks = {}
 
-    def mock_get_pool_member_list(self, partition, pool):
+    def mock_get_pool_member_list(self, pool):
         """Mock: Get a mocked list of pool members."""
         try:
             return self.bigip_data[pool]
         except KeyError:
             return []
 
-    def mock_get_node_list(self, partition):
+    def mock_get_node_list(self):
         """Mock: Get a mocked list of nodes."""
         return ['10.141.141.10']
 
@@ -449,35 +445,35 @@ class BigIPTest(unittest.TestCase):
         healthcheck.modify = Mock()
         return healthcheck
 
-    def mock_get_pool(self, partition, name):
+    def mock_get_pool(self, name):
         """Lookup a mock pool object by name."""
         return self.pools.get(name, None)
 
-    def mock_get_virtual(self, partition, name):
+    def mock_get_virtual(self, name):
         """Lookup a mock virtual server object by name."""
         return self.virtuals.get(name, None)
 
-    def mock_get_virtual_address(self, partition, name):
+    def mock_get_virtual_address(self, name):
         """Lookup a mock virtual Address object by name."""
         return name
 
-    def mock_get_member(self, partition, pool, name):
+    def mock_get_member(self, name):
         """Lookup a mock pool member object by name."""
         return self.members.get(name, None)
 
-    def mock_get_healthcheck(self, partition, hc, hc_type):
+    def mock_get_healthcheck(self, hc):
         """Lookup a mock healthcheck object by name."""
         return self.healthchecks.get(hc, None)
 
-    def mock_get_virtual_profiles(self, virtual):
+    def mock_get_virtual_profiles(self):
         """Return a list of Virtual Server profiles."""
         return self.profiles
 
-    def mock_virtual_create(self, name=None, partition=None, **kwargs):
+    def mock_virtual_create(self, name=None, partition=None):
         """Mock: Creates a mocked virtual server."""
         self.test_virtual.append({'name': name, 'partition': partition})
 
-    def mock_pool_create(self, partition=None, name=None, **kwargs):
+    def mock_pool_create(self, partition=None, name=None):
         """Mock: Create a mocked pool."""
         self.test_pool.append({'name': name, 'partition': partition})
 
@@ -508,13 +504,13 @@ class BigIPTest(unittest.TestCase):
         self.test_pool = p_collection
         return p_collection
 
-    def mock_pool_load(self, name=None, partition=None, cow=3):
+    def mock_pool_load(self, name=None):
         """Mock: Return a mocked pool."""
         pool = Pool(name)
         self.test_pool.append(pool)
         return pool
 
-    def mock_get_pool_list(self, partition, all_pools=False):
+    def mock_get_pool_list(self, partition):
         """Mock: Return previouly created pools."""
         pool_list = []
         if self.test_pool is not None:
@@ -562,15 +558,15 @@ class BigIPTest(unittest.TestCase):
             with open(bigip_state) as json_data:
                 self.bigip_data = json.load(json_data)
             self.bigip.get_pool_list = Mock(
-                    return_value=self.bigip_data.keys())
+                return_value=self.bigip_data.keys())
             self.bigip.get_virtual_list = Mock(
-                    return_value=self.bigip_data.keys())
+                return_value=self.bigip_data.keys())
         else:
             self.bigip_data = {}
             self.bigip.get_pool_list = Mock(
-                    return_value=[])
+                return_value=[])
             self.bigip.get_virtual_list = Mock(
-                    return_value=[])
+                return_value=[])
 
         if hm_state:
             with open(hm_state) as json_data:
@@ -582,27 +578,27 @@ class BigIPTest(unittest.TestCase):
             with open(network_state) as json_data:
                 self.network_data = json.load(json_data)
 
-    def raiseTypeError(self, cfg):
+    def raiseTypeError(self):
         """Raise a TypeError exception."""
         raise TypeError
 
-    def raiseSDKError(self, cfg):
+    def raiseSDKError(self):
         """Raise an F5SDKError exception."""
         raise f5.sdk_exception.F5SDKError
 
-    def raiseConnectionError(self, cfg):
+    def raiseConnectionError(self):
         """Raise a ConnectionError exception."""
         raise requests.exceptions.ConnectionError
 
-    def raiseBigIPInvalidURL(self, cfg):
+    def raiseBigIPInvalidURL(self):
         """Raise a BigIPInvalidURL exception."""
         raise icontrol.exceptions.BigIPInvalidURL
 
-    def raiseBigiControlUnexpectedHTTPError(self, cfg):
+    def raiseBigiControlUnexpectedHTTPError(self):
         """Raise an iControlUnexpectedHTTPError exception."""
         raise icontrol.exceptions.iControlUnexpectedHTTPError
 
-    def setUp(self, partition, bigip):
+    def setUp(self, partition, bigip):  # pylint: disable=arguments-differ
         """Test suite set up."""
         self.bigip = bigip
         self.test_partition = partition

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -9,6 +9,7 @@ python-coveralls==2.7.0
 pyOpenSSL==16.2.0
 requests-mock==1.2.0
 flake8
+pylint
 netaddr
 q
 PyYAML==3.12

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 envlist =
     unit
-    flake
+    style
     coveralls
     docs
 
 [testenv]
 basepython =
     unit: python
-    flake: python
+    style: python
     coveralls: python
     docs: python
 passenv = COVERALLS_REPO_TOKEN
@@ -17,11 +17,12 @@ deps =
 
 commands =
     # Misc tests
-    flake: flake8 {posargs:.}
+    style: flake8 {posargs:.}
+    style: pylint f5_cccl/
     unit: py.test f5_cccl/
     coveralls: coveralls
     docs: bash ./devtools/bin/build-docs.sh
 usedevelop = true
 
 [flake8]
-exclude = docs/conf.py,docs/userguide/code_example.py,docs/conf.py,.tox,.git,__pycache__,build,*.pyc,docs,devtools,*.tmpl
+exclude = docs/conf.py,docs/userguide/code_example.py,docs/conf.py,.tox,.git,__pycache__,build,*.pyc,docs,devtools,*.tmpl,*test*


### PR DESCRIPTION
Problem:
- Only flake8 is presently implemented on travis builds.

Solution:
- Add pylint
- Add .pylintrc to customize disables of files and checkers
- Modify existing code where oppropriate to meet pylint standards
- Add steps to travis build to run pylint

Fixes #34