### PR TITLE
Add coverage data via coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+omit =
+  # unit tests
+  */test/*
+  */testcommon.py
+
+  # setup etc.
+  setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,8 @@ install:
 script:
   - tox -e style
   - tox -e unit
+# For security, travis CI not provide env vars on fork PRs.
+# So we only run coverage when the env var is present at merge.
+# https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions
+  - if [ "$COVERALLS_REPO_TOKEN" != "" ]; then tox -e coverage; fi
 before_deploy: PKG_VERSION=$(python -c "import f5; print(f5_cccl.__version__)")

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# f5-cccl
+[![Build Status](https://travis-ci.org/michaeldayreads/f5-cccl.svg?branch=master)](https://travis-ci.org/michaeldayreads/f5-cccl) [![Coverage Status](https://coveralls.io/repos/github/f5devcentral/f5-cccl/badge.svg?branch=master)](https://coveralls.io/github/f5devcentral/f5-cccl?branch=master) 
+
 # Introduction
 
 This project implements a Common Controller Core Library for orchestration an F5 BIG-IP (r) for use within other libraries that need to read, diff and apply configurations to a BIG-IP (r).

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -15,3 +15,4 @@ q
 PyYAML==3.12
 simplejson
 jsonschema
+python-coveralls==2.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,14 @@
 envlist =
     unit
     style
-    coveralls
+    coverage
     docs
 
 [testenv]
 basepython =
     unit: python
     style: python
-    coveralls: python
+    coverage: python
     docs: python
 passenv = COVERALLS_REPO_TOKEN
 deps =
@@ -17,10 +17,10 @@ deps =
 
 commands =
     # Misc tests
+    unit: py.test --cov=f5_cccl/
     style: flake8 {posargs:.}
     style: pylint f5_cccl/
-    unit: py.test f5_cccl/
-    coveralls: coveralls
+    coverage: coveralls
     docs: bash ./devtools/bin/build-docs.sh
 usedevelop = true
 


### PR DESCRIPTION
Problem:
- Coverage data needs to be measurable and visible.

Solution:
- Configured GitHub to work with coveralls.
- Added coveralls token to travis. Coverage data is synced to coveralls at merge build to prevent ENV vars from being accessed by fork PRs.
  See https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions for details.
- Confirmed tox ini invocations included earlier via template functioned as expected.
- Added build status and coverage badges to README.md

Tests:
- Manually checked that data was available at:
- [f5devcentral coveralls](https://coveralls.io/github/f5devcentral)