### PR TITLE
Fixes 41: CCCL Pool and Pool Member Classes

### DIFF
--- a/f5_cccl/resource/ltm/pool.py
+++ b/f5_cccl/resource/ltm/pool.py
@@ -1,0 +1,136 @@
+u"""This module provides class for managing resource configuration."""
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from f5_cccl.resource.ltm.pool_member import BigIPPoolMember
+from f5_cccl.resource.ltm.pool_member import F5CcclPoolMember
+from f5_cccl.resource import Resource
+
+
+class Pool(Resource):
+    u"""Pool class for deploying configuration on BIG-IP"""
+    pool_properties = dict(name=None,
+                           partition=None,
+                           loadBalancingMode="round-robin",
+                           description=None,
+                           monitor="default",
+                           membersReference={})
+
+    def __init__(self, name, partition, members=None, **properties):
+        u"""Create a Pool instance from CCCL poolType."""
+        super(Pool, self).__init__(name, partition)
+
+        self._data['loadBalancingMode'] = properties.get(
+            'loadBalancingMode', 'round-robin')
+        self._data['description'] = properties.get(
+            'description', None)
+        self._data['monitor'] = properties.get(
+            'monitor', 'default')
+        self._data['membersReference'] = {
+            'isSubcollection': True, 'items': []}
+
+        self.members = list()
+        if members:
+            self.members = members
+            self._data['membersReference']['items'] = [
+                m.__dict__() for m in members]
+
+    def __eq__(self, other):
+        if not isinstance(other, Pool):
+            raise ValueError(
+                "Invalid comparison of Pool object with object "
+                "of type {}".format(type(other)))
+
+        other_properties = other.data
+        for key, _ in self._data.items():
+            if self._data[key] != other_properties[key]:
+                return False
+        if len(self.members) != len(other):
+            return False
+        if set(self.members) - set(other.members):
+            return False
+        return True
+
+    def __len__(self):
+        if 'items' in self._data['membersReference']:
+            return len(self._data['membersReference']['items'])
+        return 0
+
+    def __dict__(self):
+        return self._data
+
+    def _uri_path(self, bigip):
+        return bigip.tm.ltm.pools.pool
+
+    def __repr__(self):
+        pass
+
+
+class F5CcclPool(Pool):
+    """Parse the CCCL input to create the canonical Pool."""
+    def __init__(self, name, partition, **properties):
+        """Parse the CCCL schema input."""
+        pool_config = dict()
+        for k, v in properties.items():
+            if k == "members" or k == "monitor":
+                continue
+            pool_config[k] = v
+
+        members = (
+            self._get_members(partition, properties['members'])
+        )
+        super(F5CcclPool, self).__init__(name, partition,
+                                         members,
+                                         **pool_config)
+
+    def _get_members(self, partition, members=None):
+        """Get a list of members from the pool definition"""
+        members_list = list()
+        if members:
+            for member in members:
+                m = F5CcclPoolMember(name=None,
+                                     partition=partition,
+                                     pool=self,
+                                     **member)
+                members_list.append(m)
+
+        return members_list
+
+
+class BigIPPool(Pool):
+    """Filter the F5 SDK input to create the canonical Pool."""
+    def __init__(self, name, partition, **properties):
+        """Parse the BigIP SDK representation of the Pool"""
+        members = self._get_members(**properties)
+        super(BigIPPool, self).__init__(name, partition,
+                                        members,
+                                        **properties)
+
+    def _get_members(self, **properties):
+        """Get a list of members from the pool definition"""
+        try:
+            members = (
+                properties['membersReference'].get('items', [])
+            )
+        except KeyError:
+            return list()
+
+        return [
+            BigIPPoolMember(pool=self,
+                            **member)
+            for member in members]

--- a/f5_cccl/resource/ltm/pool_member.py
+++ b/f5_cccl/resource/ltm/pool_member.py
@@ -1,0 +1,176 @@
+u"""This module provides class for managing member configuration."""
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import re
+
+from f5_cccl.resource import Resource
+from netaddr import IPAddress
+from requests.utils import quote as urlquote
+
+
+class PoolMember(Resource):
+    u"""PoolMember class for deploying configuration on BIG-IP?
+
+    Encapsulate an PoolMember configuration object as defined by BIG-IP
+    into a dictionary
+    """
+    # The property names class attribute defines the names of the
+    # properties that we wish to compare.
+    properties = dict(name=None,
+                      partition=None,
+                      ratio=1,
+                      connectionLimit=0,
+                      priorityGroup=0,
+                      session="user-enabled",
+                      description=None)
+    member_name_re = re.compile("^(.*:?)%(\\d+)[\\.|\\:](\\d+)$")
+
+    def __init__(self, name, partition, pool=None, **properties):
+        """Initialize the PoolMember object."""
+        name = self._strip_route_domain_zero(name)
+        super(PoolMember, self).__init__(name, partition)
+        self._pool = pool
+        for key, value in self.properties.items():
+            if key == 'name' or key == 'partition':
+                continue
+            self._data[key] = properties.get(key, value)
+
+    def __eq__(self, other):
+        """Check the equality of the two objects.
+
+        Only compare the properties as defined in the
+        properties class dictionary.
+        """
+        if not isinstance(other, PoolMember):
+            return False
+
+        for key in self.properties:
+            if self._data[key] != other.data.get(key, None):
+
+                if key == "session":
+                    if self._check_states(other):
+                        continue
+
+                return False
+
+        return True
+
+    def _check_states(self, other):
+        """Compare desired admin state to operational state."""
+        other_session = other['session']
+
+        return ("monitor" in self._data['session'] or
+                "monitor" in other_session)
+
+    def _strip_route_domain_zero(self, name):
+        """Remove the route domain from the address, if 0."""
+        match = self.member_name_re.match(name)
+        if match and match.group(2) == "0":
+            ip_address = IPAddress(match.group(1))
+            if ip_address.version == 4:
+                name = "{}:{}".format(
+                    match.group(1), match.group(3))
+            else:
+                name = "{}.{}".format(
+                    match.group(1), match.group(3))
+        return name
+
+    def _uri_path(self, bigip):
+        if not self._pool:
+            raise NotImplementedError
+
+        with self._pool.read(bigip) as pool:
+            return pool.members_s.members
+
+    @property
+    def name(self):
+        u"""Override the name property to get quoted format.
+
+        This handles the '%' route domain marker.
+        """
+        return urlquote(self._data['name'])
+
+
+class BigIPPoolMember(PoolMember):
+    """PoolMember instantiated from F5 SDK pool member object."""
+    pass
+
+
+class F5CcclPoolMember(PoolMember):
+    """PoolMember instantiated from F5 CCCL schema input."""
+    def __init__(self, name, partition, pool=None, **properties):
+        u"""Create a PoolMember instance from CCCL PoolMemberType.
+
+        Args:
+            name (string): The name of the member <address>:<port>
+            If this is defined as None, the name will be computed
+            from the address and port.
+            partition (string): Pool member partition
+            pool (Pool): Parent pool object
+
+        Properties:
+            address (string): Member IP address
+            port (int): Member service port
+            routeDomain (dict): Route domain id and name
+            ratio (int): Member weight for ratio-member lb algorithm
+            connectionLimit (int): Max number of connections
+            priorityGroup (int): Member priority group
+            state (string): Member admin state, user-up or user-down
+            description (string): User specified description
+        """
+        if not name:
+            address = properties.get('address', None)
+            port = properties.get('port', None)
+            route_domain = properties.get('routeDomain', {})
+
+            name = self._init_member_name(
+                address,
+                port,
+                route_domain)
+        super(F5CcclPoolMember, self).__init__(name=name,
+                                               partition=partition,
+                                               pool=pool,
+                                               **properties)
+
+    @staticmethod
+    def _init_member_name(address, port, route_domain):
+        u"""Initialize the pool member address.
+
+        An address is of the form:
+        <ip_address>%<route_domain_id>
+        """
+        if not address or not port:
+            raise TypeError(
+                "F5CCCL poolMember definition must contain address and port")
+
+        ip_address = IPAddress(address)
+        rd_id = route_domain.get('id', 0)
+        if rd_id:
+            if ip_address.version == 4:
+                name_format = "{}%{}:{}"
+            else:
+                name_format = "{}%{}.{}"
+            name = name_format.format(address, rd_id, port)
+        else:
+            if ip_address.version == 4:
+                name_format = "{}:{}"
+            else:
+                name_format = "{}.{}"
+            name = name_format.format(address, port)
+
+        return name

--- a/f5_cccl/resource/ltm/test/bigip-members.json
+++ b/f5_cccl/resource/ltm/test/bigip-members.json
@@ -1,0 +1,30 @@
+{
+  "members": [
+  {
+    "state": "user-down", 
+    "kind": "tm:ltm:pool:members:membersstate", 
+    "inheritProfile": "enabled", 
+    "name": "192.168.200.2:80", 
+    "priorityGroup": 0, 
+    "generation": 137066, 
+    "partition": "Common", 
+    "ephemeral": "false", 
+    "fqdn": {
+      "autopopulate": "disabled"
+    }, 
+    "rateLimit": "disabled", 
+    "session": "user-enabled", 
+    "dynamicRatio": 1, 
+    "nameReference": {
+      "link": "https://localhost/mgmt/tm/ltm/node/~Common~192.168.200.2:80?ver=12.1.1"
+    }, 
+    "connectionLimit": 0, 
+    "address": "192.168.200.2", 
+    "logging": "disabled", 
+    "fullPath": "/Common/192.168.200.2:80", 
+    "ratio": 1, 
+    "selfLink": "https://localhost/mgmt/tm/ltm/pool/~Common~pool1/members/~Common~192.168.200.2:80?ver=12.1.1", 
+    "monitor": "default"
+  }
+  ]
+}

--- a/f5_cccl/resource/ltm/test/test_cccl_pool_member.py
+++ b/f5_cccl/resource/ltm/test/test_cccl_pool_member.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import copy
+
+from f5_cccl.resource.ltm.pool_member import F5CcclPoolMember
+from f5_cccl.resource.ltm.pool_member import PoolMember
+
+from mock import MagicMock
+# import pdb
+import pytest
+
+
+@pytest.fixture
+def members():
+    members = {
+        'member_min_config': {
+            'address': "172.16.200.100",
+            'port': 80
+        },
+        'member_w_route_domain': {
+            'address': "172.16.200.101",
+            'port': 80,
+            'routeDomain': {'id': 0}
+        },
+        'member_no_port': {
+            'address': "172.16.200.102",
+            'routeDomain': {'id': 0}
+        },
+        'member_no_address': {
+            'port': 80,
+            'routeDomain': {'id': 0}
+        },
+        'member_w_nonzero_route_domain': {
+            'address': "172.16.200.103",
+            'port': 80,
+            'routeDomain': {'id': 2}
+        },
+        'member_min_ipv6_config': {
+            'address': "2001:0db8:3c4d:0015:0000:0000:abcd:ef12",
+            'port': 80
+        },
+        'member_min_ipv6_rd_config': {
+            'address': "2001:0db8:3c4d:0015:0000:0000:abcd:ef12",
+            'port': 80,
+            'routeDomain': {'id': 2}
+        },
+        'member_min_config_w_name': {
+            'address': "172.16.200.100",
+            'port': 80,
+            'name': "192.168.200.100:80"
+        }
+    }
+    return members
+
+
+@pytest.fixture
+def bigip():
+    """Fixture that returns BIG-IP."""
+    bigip = MagicMock()
+    return bigip
+
+
+@pytest.fixture
+def pool():
+    """Fixture that returns a Pool object."""
+    return MagicMock()
+
+
+POOL_PROPERTIES = PoolMember.properties
+
+
+def test_create_cccl_member_min_config(pool, members):
+    """Test creation of F5CcclPoolMember from bare config."""
+    cfg_name = "member_min_config"
+    partition = "Common"
+
+    # pdb.set_trace()
+    member = F5CcclPoolMember(
+        name=None,
+        partition=partition,
+        pool=pool,
+        **members[cfg_name]
+    )
+
+    assert member
+
+    # Test data
+    assert member.data
+    pool_data = copy.copy(member.data)
+    for k, _ in POOL_PROPERTIES.items():
+        if k == 'name':
+            assert pool_data['name'] == "172.16.200.100:80"
+        elif k == 'partition':
+            assert pool_data['partition'] == "Common"
+        elif k == 'ratio':
+            assert pool_data['ratio'] == 1
+        elif k == 'connectionLimit':
+            assert pool_data['connectionLimit'] == 0
+        elif k == 'priorityGroup':
+            assert pool_data['priorityGroup'] == 0
+        elif k == 'session':
+            assert pool_data['session'] == "user-enabled"
+        elif k == 'description':
+            assert not pool_data['description']
+        pool_data.pop(k)
+
+    assert not pool_data, "unexpected keys found in data"
+
+
+def test_create_cccl_member_w_route_domain(pool, members):
+    """Test creation of F5CcclPoolMember from bare config w route domain."""
+    cfg_name = "member_w_route_domain"
+    partition = "Common"
+
+    member = F5CcclPoolMember(
+        name=None,
+        partition=partition,
+        pool=pool,
+        **members[cfg_name]
+    )
+
+    assert member
+
+    # Test data
+    assert member.data
+    pool_data = copy.copy(member.data)
+    for k, _ in POOL_PROPERTIES.items():
+        if k == 'name':
+            assert pool_data['name'] == "172.16.200.101:80"
+        elif k == 'partition':
+            assert pool_data['partition'] == "Common"
+        elif k == 'ratio':
+            assert pool_data['ratio'] == 1
+        elif k == 'connectionLimit':
+            assert pool_data['connectionLimit'] == 0
+        elif k == 'priorityGroup':
+            assert pool_data['priorityGroup'] == 0
+        elif k == 'session':
+            assert pool_data['session'] == "user-enabled"
+        elif k == 'description':
+            assert not pool_data['description']
+        pool_data.pop(k)
+
+    assert not pool_data, "unexpected keys found in data"
+
+
+def test_create_cccl_member_no_port(pool, members):
+    """Test of F5CcclPoolMember create without name or port."""
+    cfg_name = "member_no_port"
+    partition = "Common"
+
+    with pytest.raises(TypeError):
+        member = F5CcclPoolMember(
+            name=None,
+            partition=partition,
+            pool=pool,
+            **members[cfg_name]
+        )
+        assert not member
+
+
+def test_create_cccl_member_no_address(pool, members):
+    """Test of F5CcclPoolMember create without name or address."""
+    cfg_name = "member_no_address"
+    partition = "Common"
+
+    with pytest.raises(TypeError):
+        member = F5CcclPoolMember(
+            name=None,
+            partition=partition,
+            pool=pool,
+            **members[cfg_name]
+        )
+        assert not member
+
+
+def test_create_cccl_member_w_nonzero_route_domain(pool, members):
+    """Test of F5CcclPoolMember create with non-zero route-domain."""
+    cfg_name = "member_w_nonzero_route_domain"
+    partition = "Common"
+
+    member = F5CcclPoolMember(
+        name=None,
+        partition=partition,
+        pool=pool,
+        **members[cfg_name]
+    )
+
+    assert member
+
+    # Test data
+    assert member.data
+    pool_data = copy.copy(member.data)
+    for k, _ in POOL_PROPERTIES.items():
+        if k == 'name':
+            assert pool_data['name'] == "172.16.200.103%2:80"
+        elif k == 'partition':
+            assert pool_data['partition'] == "Common"
+        elif k == 'ratio':
+            assert pool_data['ratio'] == 1
+        elif k == 'connectionLimit':
+            assert pool_data['connectionLimit'] == 0
+        elif k == 'priorityGroup':
+            assert pool_data['priorityGroup'] == 0
+        elif k == 'session':
+            assert pool_data['session'] == "user-enabled"
+        elif k == 'description':
+            assert not pool_data['description']
+        pool_data.pop(k)
+
+    assert not pool_data, "unexpected keys found in data"
+
+
+def test_create_cccl_member_min_ipv6_config(pool, members):
+    """Test of F5CcclPoolMember create with IPv6 address."""
+    cfg_name = "member_min_ipv6_config"
+    partition = "Common"
+
+    # pdb.set_trace()
+    member = F5CcclPoolMember(
+        name=None,
+        partition=partition,
+        pool=pool,
+        **members[cfg_name]
+    )
+
+    assert member
+
+    # Test data
+    assert member.data
+    pool_data = copy.copy(member.data)
+    for k, _ in POOL_PROPERTIES.items():
+        if k == 'name':
+            assert (pool_data['name'] ==
+                    "2001:0db8:3c4d:0015:0000:0000:abcd:ef12.80")
+        elif k == 'partition':
+            assert pool_data['partition'] == "Common"
+        elif k == 'ratio':
+            assert pool_data['ratio'] == 1
+        elif k == 'connectionLimit':
+            assert pool_data['connectionLimit'] == 0
+        elif k == 'priorityGroup':
+            assert pool_data['priorityGroup'] == 0
+        elif k == 'session':
+            assert pool_data['session'] == "user-enabled"
+        elif k == 'description':
+            assert not pool_data['description']
+        pool_data.pop(k)
+
+    assert not pool_data, "unexpected keys found in data"
+
+
+def test_create_cccl_member_min_ipv6_rd_config(pool, members):
+    """Test of F5CcclPoolMember create with IPv6 address and route domain."""
+    cfg_name = "member_min_ipv6_rd_config"
+    partition = "Common"
+
+    # pdb.set_trace()
+    member = F5CcclPoolMember(
+        name=None,
+        partition=partition,
+        pool=pool,
+        **members[cfg_name]
+    )
+
+    assert member
+
+    # Test data
+    assert member.data
+    pool_data = copy.copy(member.data)
+    for k, _ in POOL_PROPERTIES.items():
+        if k == 'name':
+            assert (pool_data['name'] ==
+                    "2001:0db8:3c4d:0015:0000:0000:abcd:ef12%2.80")
+        elif k == 'partition':
+            assert pool_data['partition'] == "Common"
+        elif k == 'ratio':
+            assert pool_data['ratio'] == 1
+        elif k == 'connectionLimit':
+            assert pool_data['connectionLimit'] == 0
+        elif k == 'priorityGroup':
+            assert pool_data['priorityGroup'] == 0
+        elif k == 'session':
+            assert pool_data['session'] == "user-enabled"
+        elif k == 'description':
+            assert not pool_data['description']
+        pool_data.pop(k)
+
+    assert not pool_data, "unexpected keys found in data"
+
+
+def test_create_cccl_member_min_config_w_name(pool, members):
+    """Test of F5CcclPoolMember create with a name."""
+    cfg_name = "member_min_config_w_name"
+    partition = "Common"
+
+    # pdb.set_trace()
+    member = F5CcclPoolMember(
+        partition=partition,
+        pool=pool,
+        **members[cfg_name]
+    )
+
+    assert member
+
+    # Test data
+    assert member.data
+    pool_data = copy.copy(member.data)
+    for k, _ in POOL_PROPERTIES.items():
+        if k == 'name':
+            assert pool_data['name'] == "192.168.200.100:80"
+        elif k == 'partition':
+            assert pool_data['partition'] == "Common"
+        elif k == 'ratio':
+            assert pool_data['ratio'] == 1
+        elif k == 'connectionLimit':
+            assert pool_data['connectionLimit'] == 0
+        elif k == 'priorityGroup':
+            assert pool_data['priorityGroup'] == 0
+        elif k == 'session':
+            assert pool_data['session'] == "user-enabled"
+        elif k == 'description':
+            assert not pool_data['description']
+        pool_data.pop(k)
+
+    assert not pool_data, "unexpected keys found in data"

--- a/f5_cccl/resource/ltm/test/test_pool_member.py
+++ b/f5_cccl/resource/ltm/test/test_pool_member.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import os
+from pprint import pprint as pp
+
+from f5_cccl.resource.ltm.pool_member import BigIPPoolMember
+from f5_cccl.resource.ltm.pool_member import PoolMember
+
+
+from mock import MagicMock
+# import pdb
+import pytest
+
+
+ccclMemberA = {
+    "address": "172.16.0.100", "port": 8080, "routeDomain": {"id": 0}}
+ccclMemberB = {
+    "address": "172.16.0.101", "port": 8080, "routeDomain": {"id": 0}}
+
+
+@pytest.fixture
+def pool_member_ipv6():
+    pass
+
+
+@pytest.fixture
+def pool_member_with_rd():
+    member = {"name": "192.168.100.101%0:80"}
+    return member
+
+
+@pytest.fixture
+def pool_member_with_rd_ipv6():
+    member = {"name": "2001:0db8:3c4d:0015:0000:0000:abcd:ef12%0.80"}
+    return member
+
+
+@pytest.fixture
+def bigip():
+    bigip = MagicMock()
+    return bigip
+
+
+@pytest.fixture
+def pool():
+    return MagicMock()
+
+
+@pytest.fixture
+def bigip_members():
+    members_filename = (
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     './bigip-members.json'))
+    with open(members_filename) as fp:
+        json_data = fp.read()
+        json_data = json.loads(json_data)
+        members = [m for m in json_data['members']]
+        pp(json_data)
+
+    return members
+
+
+def test_create_bigip_member(pool, bigip_members):
+    """Test the creation of PoolMember from BIG-IP data."""
+    member_cfg = bigip_members[0]
+
+    pp(bigip_members)
+    pp(member_cfg)
+    # pdb.set_trace()
+    member = BigIPPoolMember(
+        pool=pool,
+        **member_cfg
+    )
+
+    assert member
+
+    # Test data
+    assert member.data
+    assert member.data['name'] == "192.168.200.2:80"
+    assert member.data['ratio'] == 1
+    assert member.data['connectionLimit'] == 0
+    assert member.data['priorityGroup'] == 0
+    assert member.data['session'] == "user-enabled"
+    assert not member.data['description']
+
+
+def test_create_pool_member(pool, bigip_members):
+    """Test the creation of PoolMember from BIG-IP data."""
+    member_cfg = bigip_members[0]
+
+    member = PoolMember(
+        pool=pool,
+        **member_cfg
+    )
+
+    assert member
+    assert member._pool
+
+    # Test data
+    assert member.data
+    assert member.data['name'] == "192.168.200.2:80"
+    assert member.data['ratio'] == 1
+    assert member.data['connectionLimit'] == 0
+    assert member.data['priorityGroup'] == 0
+    assert member.data['session'] == "user-enabled"
+    assert not member.data['description']
+
+
+def test_create_pool_member_with_rd(pool, pool_member_with_rd):
+    """Test the creation of PoolMember from BIG-IP data."""
+    member = PoolMember(
+        partition="Common",
+        pool=pool,
+        **pool_member_with_rd
+    )
+
+    assert member
+    assert member._pool
+
+    # Test data
+    assert member.data
+    assert member.data['name'] == "192.168.100.101:80"
+
+
+def test_create_pool_member_with_rd_ipv6(pool, pool_member_with_rd_ipv6):
+    """Test the creation of PoolMember from BIG-IP data."""
+    member = PoolMember(
+        partition="Common",
+        pool=pool,
+        **pool_member_with_rd_ipv6
+    )
+
+    assert member
+    assert member._pool
+
+    # Test data
+    assert member.data
+    assert member.data['name'] == "2001:0db8:3c4d:0015:0000:0000:abcd:ef12.80"

--- a/f5_cccl/resource/resource.py
+++ b/f5_cccl/resource/resource.py
@@ -76,6 +76,12 @@ class Resource(object):
         return (self._data['name'] == resource.name and
                 self._data['partition'] == resource.partition)
 
+    def __ne__(self, resource):
+        return not self.__eq__(resource)
+
+    def __hash__(self):
+        return hash(self._data['name'] + self._data['partition'])
+
     def create(self, bigip):
         u"""Create resource on a BIG-IP system.
 
@@ -210,13 +216,10 @@ class Resource(object):
         u"""Extract the error code and reraise a CCCL Error."""
         code = error.response.status_code
         if code == 404:
-            raise cccl_exc.F5CcclResourceNotFoundError(
-                error.response.message)
+            raise cccl_exc.F5CcclResourceNotFoundError(str(error))
         elif code == 409:
-            raise cccl_exc.F5CcclResourceConflictError(
-                error.response.message)
+            raise cccl_exc.F5CcclResourceConflictError(str(error))
         elif code >= 400 and code < 500:
-            raise cccl_exc.F5CcclResourceRequestError(
-                error.response.message)
+            raise cccl_exc.F5CcclResourceRequestError(str(error))
         else:
-            raise cccl_exc.F5CcclError(error.response.message)
+            raise cccl_exc.F5CcclError(str(error))

--- a/schemas/cccl-api-schema.yml
+++ b/schemas/cccl-api-schema.yml
@@ -224,7 +224,11 @@
     poolMemberType: 
       id: "#/definitions/poolMemberType"
       type: "object"
-      properties: 
+      properties:
+        name:
+          type: "string"
+          definition: |
+            "Specifies the name of the pool member.  This has the form: <address>:<port>"
         connectionLimit:
           type: "integer"
           definition: |
@@ -302,7 +306,7 @@
           items:
             $ref: "#definitions/poolMemberType"
             type: "array"
-        monitors: 
+        monitor:
           items: 
             properties: 
               refname: 


### PR DESCRIPTION
Problem:
Need exists for a Pool CCCL Class that handles BIG-IP monitors
Need exists for a PoolMember CCCL Class that handles BIG-IP monitors
These classes will need to interface with the F5-SDK monitor

Analysis:
Created Pool, F5CcclPool, and BigIPPool Classes
Created PoolMember, F5CcclPoolMember, and BigIPPoolMember Classes

Tests:
resource/ltm/test/test_pool_member.py