### PR TITLE
Collect existing BIG-IP config state

### DIFF
--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -1,3 +1,4 @@
+u"""This module provides a class for managing a BIG-IP."""
 # coding=utf-8
 #
 # Copyright 2017 F5 Networks Inc.

--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -1,0 +1,88 @@
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from f5_cccl.resource.ltm.pool import BigIPPool
+from f5.bigip import BigIP
+import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+
+class CommonBigIP(BigIP):
+    """CommonBigIP class.
+
+    Manages the resources for the partition(s) of the specified BIG-IP
+
+    - Token-based authentication is used by specifying a token named 'tmos'.
+      This will allow non-admin users to use the API (BIG-IP must configure
+      the accounts with proper permissions, for either local or remote auth).
+
+    Args:
+        hostname: IP address of BIG-IP
+        port: Port of BIG-IP
+        username: BIG-IP username
+        password: BIG-IP password
+        partitions: List of BIG-IP partitions to manage
+        token: The optional auth token to use with BIG-IP (e.g. "tmos")
+    """
+
+    def __init__(self, hostname, port, username, password, partitions,
+                 token=None, manage_types=None):
+        """Initialize the CommonBigIP object."""
+        super_kwargs = {"port": port}
+        if token:
+            super_kwargs["token"] = token
+        super(CommonBigIP, self).__init__(hostname, username, password,
+                                          **super_kwargs)
+        self._hostname = hostname
+        self._port = port
+        self._username = username
+        self._password = password
+        self._partitions = partitions
+
+        # This currently hard codes what resources we care about until we
+        # enable policy management.
+        if manage_types is None:
+            manage_types = ['/tm/ltm/virtual', '/tm/ltm/pool',
+                            '/tm/ltm/monitor', '/tm/sys/application/service']
+
+        self._manage_virtual = '/tm/ltm/virtual' in manage_types
+        self._manage_pool = '/tm/ltm/pool' in manage_types
+        self._manage_monitor = '/tm/ltm/monitor' in manage_types
+        self._manage_policy = '/tm/ltm/policy' in manage_types
+        self._manage_iapp = '/tm/sys/application/service' in manage_types
+
+        # BIG-IP resources
+        self._virtuals = []
+        self._pools = []
+        self._polices = []
+        self._iapps = []
+        self._monitors = []
+
+    def refresh(self):
+        """Refresh the internal cache with the BIG-IP state."""
+        new_pools = []
+        pools = self.ltm.pools.get_collection(
+            requests_params={"params": "expandSubcollections=true"})
+
+        for p in pools:
+            pool = BigIPPool(**p.__dict__)
+            new_pools.append(pool)
+
+        self._pools = new_pools
+
+        # TODO: Refresh iapps, virtuals, monitors, and policies

--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -86,4 +86,4 @@ class CommonBigIP(BigIP):
 
         self._pools = new_pools
 
-        # TODO: Refresh iapps, virtuals, monitors, and policies
+        # FIXME: Refresh iapps, virtuals, monitors, and policies

--- a/f5_cccl/test/bigip_data.json
+++ b/f5_cccl/test/bigip_data.json
@@ -1,0 +1,174 @@
+{
+    "pools": [
+        {
+            "allowNat": "yes",
+            "allowSnat": "yes",
+            "fullPath": "/Common/test_pool",
+            "generation": 15837,
+            "ignorePersi$stedWeight": "disabled",
+            "ipTosToClient": "pass-through",
+            "ipTosToServer": "pass-through",
+            "kind": "tm:ltm:pool:poolstate",
+            "linkQosToClient": "pass-through",
+            "linkQosToServer": "pass-through",
+            "loadBalancingMode": "least-connections-member",
+            "membersReference": {
+                "isSubcollection": true,
+                "items": [
+                    {
+                        "address": "1.2.3.4",
+                        "connectionLimit": 0,
+                        "dynamicRatio": 1,
+                        "ephemeral": "false",
+                        "fqdn": {
+                            "autopopulate": "disabled"
+                        },
+                        "fullPath": "/Common/1.2.3.4:20001",
+                        "generation": 15835,
+                        "inheritProfile": "enabled",
+                        "kind": "tm:ltm:pool:members:membersstate",
+                        "logging": "disabled",
+                        "monitor": "default",
+                        "name": "1.2.3.4:20001",
+                        "nameReference": {
+                            "link": "https://localhost/mgmt/tm/ltm/node/~Common~1.2.3.4:20001?ver=12.1.0"
+                        },
+                        "partition": "Common",
+                        "priorityGroup": 0,
+                        "rateLimit": "disabled",
+                        "ratio": 1,
+                        "selfLink": "https://localhost/mgmt/tm/ltm/pool/~Common~test_pool/members/~Common~1.2.3.4:20001?ver=12.1.0",
+                        "session": "monitor-enabled",
+                        "state": "down"
+                    },
+                    {
+                        "address": "1.2.3.4",
+                        "connectionLimit": 0,
+                        "dynamicRatio": 1,
+                        "ephemeral": "false",
+                        "fqdn": {
+                            "autopopulate": "disabled"
+                        },
+                        "fullPath": "/Common/1.2.3.4:20002",
+                        "generation": 15837,
+                        "inheritProfile": "enabled",
+                        "kind": "tm:ltm:pool:members:membersstate",
+                        "logging": "disabled",
+                        "monitor": "default",
+                        "name": "1.2.3.4:20002",
+                        "nameReference": {
+                            "link": "https://localhost/mgmt/tm/ltm/node/~Common~1.2.3.4:20002?ver=12.1.0"
+                        },
+                        "partition": "Common",
+                        "priorityGroup": 0,
+                        "rateLimit": "disabled",
+                        "ratio": 1,
+                        "selfLink": "https://localhost/mgmt/tm/ltm/pool/~Common~test_pool/members/~Common~1.2.3.4:20002?ver=12.1.0",
+                        "session": "monitor-enabled",
+                        "state": "down"
+                    }
+                ],
+                "link": "https://localhost/mgmt/tm/ltm/pool/~Common~test_pool/members?ver=12.1.0"
+            },
+            "minActiveMembers": 0,
+            "minUpMembers": 0,
+            "minUpMembersAction": "failover",
+            "minUpMembersChecking": "disabled",
+            "monitor": "/Common/http ",
+            "name": "test_pool",
+            "partition": "Common",
+            "queueDepthLimit": 0,
+            "queueOnConnectionLimit": "disabled",
+            "queueTimeLimit": 0,
+            "reselectTries": 0,
+            "selfLink": "https://localhost/mgmt/tm/ltm/pool/~Common~test_pool?ver=12.1.0",
+            "serviceDownAction": "no$ne",
+            "slowRampTime": 10
+        },
+        {
+            "allowNat": "yes",
+            "allowSnat": "yes",
+            "fullPath": "/test/pool1",
+            "generation": 15844,
+            "ignorePersistedWeight": "disabled",
+            "ipTosToClient": "pass-through",
+            "ipTosToServer": "pass-through",
+            "kind": "tm:ltm:pool:poolstate",
+            "linkQosToClient": "pass-through",
+            "linkQosToServer": "pass-through",
+            "loadBalancingMode": "round-robin",
+            "membersReference": {
+                "isSubcollection": true,
+                "items": [
+                    {
+                        "address": "5.6.7.8",
+                        "connectionLimit": 0,
+                        "dynamicRatio": 1,
+                        "ephemeral": "false",
+                        "fqdn": {
+                            "autopopulate": "disabled"
+                        },
+                        "fullPath": "/test/5.6.7.8:30001",
+                        "generation": 15842,
+                        "inheritProfile": "enabled",
+                        "kind": "tm:ltm:pool:members:membersstate",
+                        "logging": "disabled",
+                        "monitor": "default",
+                        "name": "5.6.7.8:30001",
+                        "nameReference": {
+                            "link": "https://localhost/mgmt/tm/ltm/node/~test~5.6.7.8:30001?ver=12.1.0"
+                        },
+                        "partition": "test",
+                        "priorityGroup": 0,
+                        "rateLimit": "disabled",
+                        "ratio": 1,
+                        "selfLink": "https://localhost/mgmt/tm/ltm/pool/~test~pool1/members/~test~5.6.7.8:30001?ver=12.1.0",
+                        "session": "monitor-enabled",
+                        "state": "down"
+                    },
+                    {
+                        "address": "5.6.7.8",
+                        "connectionLimit": 0,
+                        "dynamicRatio": 1,
+                        "ephemeral": "false",
+                        "fqdn": {
+                            "autopopulate": "disabled"
+                        },
+                        "fullPath": "/test/5.6.7.8:30002",
+                        "generation": 15844,
+                        "inheritProfile": "enabled",
+                        "kind": "tm:ltm:pool:members:membersstate",
+                        "logging": "disabled",
+                        "monitor": "default",
+                        "name": "5.6.7.8:30002",
+                        "nameReference": {
+                            "link": "https://localhost/mgmt/tm/ltm/node/~test~5.6.7.8:30002?ver=12.1.0"
+                        },
+                        "partition": "test",
+                        "priorityGroup": 0,
+                        "rateLimit": "disabled",
+                        "ratio": 1,
+                        "selfLink": "https://localhost/mgmt/tm/ltm/pool/~test~pool1/members/~test~5.6.7.8:30002?ver=12.1.0",
+                        "session": "monitor-enabled",
+                        "state": "down"
+                    }
+                ],
+                "link": "https://localhost/mgmt/tm/ltm/pool/~test~pool1/members?ver=12.1.0"
+            },
+            "minActiveMembers": 0,
+            "minUpMembers": 0,
+            "minUpMembersAction": "failover",
+            "minUpMembersChecking": "disabled",
+            "monitor": "/Common/tcp ",
+            "name": "pool1",
+            "partition": "test",
+            "queueDepthLimit": 0,
+            "queueOnConnectionLimit": "disabled",
+            "queueTimeLimit": 0,
+            "reselectTries": 0,
+            "selfLink": "https://localhost/mgmt/tm/ltm/pool/~test~pool1?ver=12.1.0",
+            "serviceDownAction": "none",
+            "slowRampTime": 10
+        }
+    ]
+}

--- a/f5_cccl/test/test_bigip.py
+++ b/f5_cccl/test/test_bigip.py
@@ -436,5 +436,6 @@ def test_bigip_refresh(big_ip, bigip_state='f5_cccl/test/bigip_data.json'):
     for p in test_pools:
         p._data['loadBalancingMode'] = 'Not a valid LB mode'
 
-    for a, b in map(None, big_ip._pools, test_pools):
+    assert len(big_ip._pools) == len(test_pools)
+    for a, b in zip(big_ip._pools, test_pools):
         assert a != b

--- a/f5_cccl/test/test_bigip.py
+++ b/f5_cccl/test/test_bigip.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from f5_cccl import bigip
+from f5.bigip import BigIP
+from f5_cccl.resource.ltm.pool import BigIPPool
+import json
+from mock import Mock, patch
+import pytest
+
+
+class Pool():
+    """A mock BIG-IP Pool."""
+
+    def __init__(self, name, **kwargs):
+        """Initialize the object."""
+        self.name = name
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+
+    def modify(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def update(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def create(self, partition=None, name=None, **kwargs):
+        """Create the pool object."""
+        pass
+
+    def delete(self):
+        """Delet the pool object."""
+        pass
+
+
+class Member():
+    """A mock BIG-IP Pool Member."""
+
+    def __init__(self, name, **kwargs):
+        """Initialize the object."""
+        self.name = name
+        self.session = kwargs.get('session', None)
+        if kwargs.get('state', None) == 'user-up':
+            self.state = 'up'
+        else:
+            self.state = 'user-down'
+
+    def modify(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+
+class Profiles():
+    """A container of Virtual Server Profiles."""
+
+    def __init__(self, **kwargs):
+        """Initialize the object."""
+        self.profiles = kwargs.get('profiles', [])
+
+    def exists(self, name, partition):
+        """Check for the existance of a profile."""
+        for p in self.profiles:
+            if p['name'] == name and p['partition'] == partition:
+                return True
+
+        return False
+
+    def create(self, name, partition):
+        """Placeholder: This will be mocked."""
+        pass
+
+
+class ProfileSet():
+    """A set of Virtual Server Profiles."""
+
+    def __init__(self, **kwargs):
+        """Initialize the object."""
+        self.profiles = Profiles(**kwargs)
+
+
+class Virtual():
+    """A mock BIG-IP Virtual Server."""
+
+    def __init__(self, name, **kwargs):
+        """Initialize the object."""
+        self.profiles_s = ProfileSet(**kwargs)
+        self.name = name
+        self.enabled = kwargs.get('enabled', None)
+        self.disabled = kwargs.get('disabled', None)
+        self.ipProtocol = kwargs.get('ipProtocol', None)
+        self.destination = kwargs.get('destination', None)
+        self.pool = kwargs.get('pool', None)
+        self.sourceAddressTranslation = kwargs.get('sourceAddressTranslation',
+                                                   None)
+        self.profiles = kwargs.get('profiles', [])
+        self.partition = kwargs.get('partition', None)
+
+    def modify(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def create(self, name=None, partition=None, **kwargs):
+        """Create the virtual object."""
+        pass
+
+    def delete(self):
+        """Delete the virtual object."""
+        pass
+
+    def load(self, name=None, partition=None):
+        """Load the virtual object."""
+        pass
+
+
+class HealthCheck():
+    """A mock BIG-IP Health Monitor."""
+
+    def __init__(self, name, **kwargs):
+        """Initialize the object."""
+        self.name = name
+        self.interval = kwargs.get('interval', None)
+        self.timeout = kwargs.get('timeout', None)
+        self.send = kwargs.get('send', None)
+        self.partition = kwargs.get('partition', None)
+
+    def modify(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def delete(self):
+        """Delete the healthcheck object."""
+        pass
+
+
+class VxLANTunnel():
+    """A mock BIG-IP VxLAN tunnel."""
+
+    def __init__(self, partition, name, initial_records):
+        """Initialize the object."""
+        self.partition = partition
+        self.name = name
+        self.records = initial_records
+
+    def update(self, **kwargs):
+        """Update list of vxlan records."""
+        self.records = []
+        if 'records' in kwargs:
+            self.records = kwargs['records']
+
+
+class MockService():
+    """A mock Services service object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        pass
+
+    def load(self, name, partition):
+        """Load a mock iapp."""
+        pass
+
+    def create(self, name=None, template=None, partition=None, variables=None,
+               tables=None, trafficGroup=None, description=None):
+        """Create a mock iapp."""
+        pass
+
+
+class MockServices():
+    """A mock Application services object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.service = MockService()
+
+    def get_collection(self):
+        """Get collection of iapps."""
+        return []
+
+
+class MockApplication():
+    """A mock Sys application object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.services = MockServices()
+
+
+class MockFolders():
+    """A mock Sys folders object."""
+
+    def __init__(self):
+        """Initialize the object."""
+
+    def get_collection():
+        """Get collection of partitions."""
+        pass
+
+
+class MockSys():
+    """A mock BIG-IP sys object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.application = MockApplication()
+        self.folders = MockFolders()
+
+
+class MockIapp():
+    """A mock BIG-IP iapp object."""
+
+    def __init__(self, name=None, template=None, partition=None,
+                 variables=None, tables=None, trafficGroup=None,
+                 description=None):
+        """Initialize the object."""
+        self.name = name
+        self.partition = partition
+        self.template = template
+        self.variables = variables
+        self.tables = tables
+        self.trafficGroup = trafficGroup
+        self.description = description
+
+    def delete(self):
+        """Mock delete method."""
+        pass
+
+    def update(self, executeAction=None, name=None, partition=None,
+               variables=None, tables=None, **kwargs):
+        """Mock update method."""
+        pass
+
+
+class MockFolder():
+    """A mock BIG-IP folder object."""
+
+    def __init__(self, name):
+        """Initialize the object."""
+        self.name = name
+
+
+class MockHttp():
+    """A mock Https http object."""
+
+    def __init__(self):
+        """Initialize the object."""
+
+    def create(self, partition=None, **kwargs):
+        """Create a http healthcheck object."""
+        pass
+
+    def load(self, name=None, partition=None):
+        """Load a http healthcheck object."""
+        pass
+
+
+class MockHttps():
+    """A mock Monitor https object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.http = MockHttp
+
+    def get_collection(self):
+        """Get collection of http healthchecks."""
+        pass
+
+
+class MockTcp():
+    """A mock Tcps tcp object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        pass
+
+    def create(self, partition=None, **kwargs):
+        """Create a tcp healthcheck object."""
+        pass
+
+    def load(self, name=None, partition=None):
+        """Load a tcp healthcheck object."""
+        pass
+
+
+class MockTcps():
+    """A mock Monitor tcps object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.tcp = MockTcp()
+
+    def get_collection(self):
+        """Get collection of tcp healthchecks."""
+        pass
+
+
+class MockMonitor():
+    """A mock Ltm monitor object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.https = MockHttps()
+        self.tcps = MockTcps()
+
+
+class MockVirtuals():
+    """A mock Ltm virtuals object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.virtual = Virtual('test')
+
+    def get_collection(self):
+        """Get collection of virtuals."""
+        pass
+
+
+class MockPools():
+    """A mock Ltm pools object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.pool = Pool('test')
+
+    def get_collection(self):
+        """Get collection of pools."""
+        pass
+
+
+class MockLtm():
+    """A mock BIG-IP ltm object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.monitor = MockMonitor()
+        self.virtuals = MockVirtuals()
+        self.pools = MockPools()
+
+
+class MockHealthMonitor():
+    """A mock BIG-IP healthmonitor object."""
+
+    def __init__(self, name, partition):
+        """Initialize the object."""
+        self.name = name
+        self.partition = partition
+
+
+class BigIPTest(bigip.CommonBigIP):
+    """BIG-IP configuration tests.
+
+    Test BIG-IP configuration given various cloud states and existing
+    BIG-IP states
+    """
+
+    def create_mock_pool(self, name, **kwargs):
+        """Create a mock pool server object."""
+        pool = Pool(name, **kwargs)
+        self.pools[name] = pool
+        pool.modify = Mock()
+        return pool
+
+    def create_mock_pool_member(self, name, **kwargs):
+        """Create a mock pool member object."""
+        member = Member(name, **kwargs)
+        self.members[name] = member
+        member.modify = Mock()
+        return member
+
+    def mock_pools_get_collection(self, requests_params=None):
+        """Mock: Return a mocked collection of pools."""
+        pools = []
+        for p in self.bigip_data['pools']:
+            pool = Pool(**p)
+            pools.append(pool)
+
+        return pools
+
+    def read_test_data(self, bigip_state):
+        """Read test data for the Big-IP state."""
+        # Read the BIG-IP state
+        with open(bigip_state) as json_data:
+            self.bigip_data = json.load(json_data)
+
+
+@pytest.fixture()
+def big_ip():
+    """Fixture to supply a moked BIG-IP."""
+    # Mock the call to _get_tmos_version(), which tries to make a
+    # connection
+    with patch.object(BigIP, '_get_tmos_version'):
+        big_ip = BigIPTest('1.2.3.4', '443', 'admin', 'admin', ['test1'])
+
+    big_ip.sys = MockSys()
+    big_ip.ltm = MockLtm()
+
+    big_ip.ltm.pools.get_collection = \
+        Mock(side_effect=big_ip.mock_pools_get_collection)
+
+    return big_ip
+
+
+def test_bigip_refresh(big_ip, bigip_state='f5_cccl/test/bigip_data.json'):
+    """Test BIG-IP refresh function."""
+    big_ip.read_test_data(bigip_state)
+
+    test_pools = []
+    for p in big_ip.bigip_data['pools']:
+        pool = BigIPPool(**p)
+        test_pools.append(pool)
+
+    # refresh the BIG-IP state
+    big_ip.refresh()
+
+    # verify pools and pool members
+    assert big_ip.ltm.pools.get_collection.called
+    assert len(big_ip._pools) == 2
+
+    for a, b in map(None, big_ip._pools, test_pools):
+        assert a == b
+
+    # Make a change, pools will not be equal
+    for p in test_pools:
+        p._data['loadBalancingMode'] = 'Not a valid LB mode'
+
+    for a, b in map(None, big_ip._pools, test_pools):
+        assert a != b


### PR DESCRIPTION
Problem:
Need to access the BIG-IP, fetch the state of BIG-IP resources,
and maintain a cache of these resources.

Solution:
Created a CommonBigIP class (very similar to CloudBigIP from
_f5.py) that wraps the f5.bigip class. The refresh() method calls
the get_collection() methods from the SDK, instantiates the resource
objects, and saves them in the cache.

Only implemented for pools and pool members; resource classes for
virtuals, services (iapps), monitors, and policies are not yet
defined.