### PR TITLE
Fail builds on TODO, remove dup requirement

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -243,7 +243,7 @@ logging-modules=logging
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX,TODO
+notes=FIXME
 
 
 [SIMILARITIES]

--- a/f5_cccl/resource/ltm/http_monitor.py
+++ b/f5_cccl/resource/ltm/http_monitor.py
@@ -57,5 +57,3 @@ def _entry():
 if __name__ != '__main__':
     # Don't want bad users directly executing this...
     _entry()
-
-# vim: set expandtab tabstop=4

--- a/f5_cccl/resource/ltm/https_monitor.py
+++ b/f5_cccl/resource/ltm/https_monitor.py
@@ -57,5 +57,3 @@ def _entry():
 if __name__ != '__main__':
     # Don't want bad users directly executing this...
     _entry()
-
-# vim: set expandtab tabstop=4

--- a/f5_cccl/resource/ltm/icmp_monitor.py
+++ b/f5_cccl/resource/ltm/icmp_monitor.py
@@ -57,5 +57,3 @@ def _entry():
 if __name__ != '__main__':
     # Don't want bad users directly executing this...
     _entry()
-
-# vim: set expandtab tabstop=4

--- a/f5_cccl/resource/ltm/tcp_monitor.py
+++ b/f5_cccl/resource/ltm/tcp_monitor.py
@@ -58,4 +58,3 @@ def _entry():
 if __name__ != '__main__':
     # Don't want bad users directly executing this...
     _entry()
-# vim: set expandtab tabstop=4

--- a/f5_cccl/resource/resource.py
+++ b/f5_cccl/resource/resource.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-# vim: set fileencoding=utf-8
 # -*- coding: utf-8 -*-
 u"""This module provides class for managing resource configuration."""
 #

--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -1,6 +1,5 @@
 # F5-CCCL Install Requirements
 f5-sdk==2.2.2
-pyyaml
 ipaddress==1.0.17
 PyJWT==1.4.0
 PyYAML==3.12


### PR DESCRIPTION
Problem:
- Defaulte pylint settings accept TODO, XXX comments - FIXME is the standard we are following
- both pyyaml and PyYAML are in the requirements file
- files should not include vim formatting comments