### PR TITLE
remove deprecated tox stage, annotate fixme

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -243,7 +243,11 @@ logging-modules=logging
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME
+# List of note tags to call out, separated by a comma. These exceptions will
+# fail the build - by convention this repo permits the format of
+# FIXME
+# as a discouraged, but acceptable and should point to a filed issue.
+notes=XXX,TODO,todo,Todo,ToDo
 
 
 [SIMILARITIES]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist =
     coverage
     functional
     flake
-    coveralls
     docs
 
 [testenv]
@@ -15,7 +14,6 @@ basepython =
     coverage: python
     functional: python
     flake: python
-    coveralls: python
     docs: python
 passenv = COVERALLS_REPO_TOKEN
 deps =
@@ -30,7 +28,6 @@ commands =
     flake: flake8 {posargs:.}
     unit: py.test ./f5_cccl
     functional: py.test ./test
-    coveralls: coveralls
     docs: bash ./devtools/bin/build-docs.sh
 usedevelop = true
 


### PR DESCRIPTION
Problem:
- tox file included references to a prior stage name
- pylintrc FIXME was inverted, guidance on usage was confusing

Solution:
- removed references to "coveralls" stage, which was renamed "coverage" since that stage is needed and "coveralls" is an implementation detail
- corrected pylintrc section on which notes to flag
- added comments to pylintrc to make usage for note flagging more explicit