### PR TITLE
Fixes for Python3 compatability

### DIFF
--- a/f5_cccl/resource/ltm/pool.py
+++ b/f5_cccl/resource/ltm/pool.py
@@ -70,7 +70,7 @@ class Pool(Resource):
 
         return True
 
-    def __hash__(self):
+    def __hash__(self):  # pylint: disable=useless-super-delegation
         return super(Pool, self).__hash__()
 
     def __len__(self):

--- a/f5_cccl/resource/ltm/pool_member.py
+++ b/f5_cccl/resource/ltm/pool_member.py
@@ -51,7 +51,7 @@ class PoolMember(Resource):
                 continue
             self._data[key] = properties.get(key, value)
 
-    def __hash__(self):
+    def __hash__(self):  # pylint: disable=useless-super-delegation
         return super(PoolMember, self).__hash__()
 
     def __eq__(self, other):

--- a/f5_cccl/resource/ltm/pool_member.py
+++ b/f5_cccl/resource/ltm/pool_member.py
@@ -44,11 +44,15 @@ class PoolMember(Resource):
         """Initialize the PoolMember object."""
         name = self._strip_route_domain_zero(name)
         super(PoolMember, self).__init__(name, partition)
+
         self._pool = pool
         for key, value in self.properties.items():
             if key == 'name' or key == 'partition':
                 continue
             self._data[key] = properties.get(key, value)
+
+    def __hash__(self):
+        return super(PoolMember, self).__hash__()
 
     def __eq__(self, other):
         """Check the equality of the two objects.
@@ -72,9 +76,9 @@ class PoolMember(Resource):
 
     def _check_states(self, other):
         """Compare desired admin state to operational state."""
-        other_session = other['session']
+        other_session = other.data['session']
 
-        return ("monitor" in self._data['session'] or
+        return ("monitor" in self.data['session'] or
                 "monitor" in other_session)
 
     def _strip_route_domain_zero(self, name):
@@ -142,6 +146,7 @@ class F5CcclPoolMember(PoolMember):
                 address,
                 port,
                 route_domain)
+
         super(F5CcclPoolMember, self).__init__(name=name,
                                                partition=partition,
                                                pool=pool,

--- a/f5_cccl/resource/resource.py
+++ b/f5_cccl/resource/resource.py
@@ -73,14 +73,18 @@ class Resource(object):
             True if equal
             False otherwise
         """
-        return (self._data['name'] == resource.name and
-                self._data['partition'] == resource.partition)
+        # return (self._data['name'] == resource.name and
+        #        self._data['partition'] == resource.partition)
+        return (self._data == resource.data)
 
     def __ne__(self, resource):
         return not self.__eq__(resource)
 
     def __hash__(self):
-        return hash(self._data['name'] + self._data['partition'])
+        return hash((self.name, self.partition))
+
+    def __lt__(self, resource):
+        return self.full_path() < resource.full_path()
 
     def create(self, bigip):
         u"""Create resource on a BIG-IP system.
@@ -212,6 +216,10 @@ class Resource(object):
     def data(self):
         u"""Get the internal data model for this resource."""
         return self._data
+
+    def full_path(self):
+        u"""Concatenate the partition and name to form fullPath."""
+        return "/{}/{}".format(self.partition, self.name)
 
     def _uri_path(self, bigip):
         u"""Get the URI resource path key for the F5 SDK.

--- a/f5_cccl/resource/resource.py
+++ b/f5_cccl/resource/resource.py
@@ -73,9 +73,7 @@ class Resource(object):
             True if equal
             False otherwise
         """
-        # return (self._data['name'] == resource.name and
-        #        self._data['partition'] == resource.partition)
-        return (self._data == resource.data)
+        return self._data == resource.data
 
     def __ne__(self, resource):
         return not self.__eq__(resource)

--- a/f5_cccl/resource/test/test_resource.py
+++ b/f5_cccl/resource/test/test_resource.py
@@ -136,7 +136,48 @@ def test_resource_not_equal():
     res2 = Resource(name="other_resource", partition="Common")
 
     assert not res1.__eq__(res2)
+    assert res1 != res2
     assert not res1 == res2
+
+
+def test_resource_less_than():
+    u"""Test the __eq__ operation for Resouces."""
+    data = resource_data()
+
+    res1 = Resource(**data)
+    res2 = Resource(name="other_resource", partition="Common")
+
+    assert not res1 < res2
+    assert res1 != res2
+    assert res2 < res1
+
+
+def test_resource_get_dict():
+    u"""Test the __eq__ operation for Resouces."""
+    data = resource_data()
+
+    res1 = Resource(**data)
+
+    assert res1.data == res1.__dict__()
+
+
+def test_resource_hash():
+    u"""Test the __eq__ operation for Resouces."""
+    data = resource_data()
+
+    res1 = Resource(**data)
+    res2 = Resource(**data)
+
+    assert hash(res1) == hash(res2)
+
+
+def test_resource_fullpath():
+    u"""Test the __eq__ operation for Resouces."""
+    data = resource_data()
+
+    res1 = Resource(**data)
+
+    assert res1.full_path() == "/Common/test_resource"
 
 
 def test_delete_resource(bigip):
@@ -228,6 +269,22 @@ def test_update_subresource(bigip):
     assert not obj
     bigip.tm.ltm.subresources.subresource.load.assert_called()
     bigip.tm.ltm.subresources.subresource.obj.update.assert_called()
+
+
+def test_modify_subresource(bigip):
+    u"""Test that a subclass of Resource will execute 'update'."""
+    data = resource_data()
+    subres = SubResource(name=data['name'], partition=data['partition'])
+
+    bigip.tm.ltm.subresources.subresource.modify.return_value = (None)
+    bigip.tm.ltm.subresources.subresource.load.return_value = (
+        bigip.tm.ltm.subresources.subresource.obj
+    )
+    obj = subres.update(bigip, data=data, modify=True)
+
+    assert not obj
+    bigip.tm.ltm.subresources.subresource.load.assert_called()
+    bigip.tm.ltm.subresources.subresource.obj.modify.assert_called()
 
 
 def test_delete_subresource(bigip):

--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -1,6 +1,7 @@
 # F5-CCCL Install Requirements
 f5-sdk==2.2.2
 ipaddress==1.0.17
+netaddr
 PyJWT==1.4.0
 PyYAML==3.12
 requests==2.9.1


### PR DESCRIPTION
Author: richbrowne <r.browne@f5.com>
Date:   Mon May 22 13:43:36 2017 -0600

    Fixes Pylint useless-super-delegation warning

    Problem:
    We need to add a __hash__ function for Pool and PoolMember
    but pylint complains.

    Analysis:
    Explicitly silence the warning.

    Tests:

commit 29ac975592af35e9d71f3e69e8f65ef06493f697
Author: richbrowne <r.browne@f5.com>
Date:   Mon May 22 11:50:17 2017 -0600

    Increase test coverage for resource.py

    Problem:
    The Resource class was extended without increasing the test coverage
    New testing should be added.

    Analysis:
    Add extra unit tests

    Tests:
    test_resource.py

commit 4e80925a5e5df2108e6c81d44c70b47a91a28dd6
Author: richbrowne <r.browne@f5.com>
Date:   Mon May 22 11:47:33 2017 -0600

    Fixes #67: Pool and PoolMember need to implement __hash__

    Problem:
    The Pool and PoolMember classes implement eq and according
    to the Python3 data model must also implement the hash if
    they are to be manipulated in a Set.

    Analysis:
    Add a call to the super.hash

    Tests:
    test/pool_member.py

commit 28fd9789c3125d929fbecdbdc9650a1606c13f27
Author: richbrowne <r.browne@f5.com>
Date:   Mon May 22 11:30:14 2017 -0600

    Fixes #66: Add netaddr package to requirements

    Problem:
    pool_member.py imports netaddr for address manipulation.  It is not
    included in requirements.

    Analysis:
    Update requirements to include netaddr

    Tests:
    tox -e unit