### PR TITLE
Remove inherited tcp profiles from sdk profiles.

### DIFF
--- a/f5_cccl/_f5.py
+++ b/f5_cccl/_f5.py
@@ -816,6 +816,14 @@ class CloudBigIP(BigIP):
 
         # Compare the actual and desired profiles
         profiles = self.get_virtual_profiles(v)
+
+        # Remove inherited tcp profile of an http profile from SDK profiles
+        http_profiles = [p for p in data['profiles'] if p['name'] == 'http']
+        for http_p in http_profiles:
+            inherited_tcp_p = {'name': 'tcp', 'partition': http_p['partition']}
+            if inherited_tcp_p in profiles:
+                profiles.remove(inherited_tcp_p)
+
         no_profile_change = sorted(profiles) == sorted(data['profiles'])
 
         if no_change and no_profile_change:


### PR DESCRIPTION
Problem:
 http virtual servers automatically have both tcp and http profiles
 attached to them by the BIG-IP. This was causing http virtual servers
 to have update called every verify interval even though nothing had
 actually changed. This was due to the comparison logic in
 virtual_update.

Solution:
 Add logic to remove inherited tcp profiles (from http profiles) in the
 profiles list returned by the SDK to prevent a profile comparison
 mismatch that was causing the virtual server to be updated at every
 verify interval.

Fixes: #75