### PR TITLE
Fixes Add virtuals and monitors to CommonBigIP

### DIFF
--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -15,16 +15,22 @@ u"""This module provides a class for managing a BIG-IP."""
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from f5_cccl.resource.ltm.monitor.http_monitor import HTTPMonitor
+from f5_cccl.resource.ltm.monitor.https_monitor import HTTPSMonitor
+from f5_cccl.resource.ltm.monitor.icmp_monitor import ICMPMonitor
+from f5_cccl.resource.ltm.monitor.tcp_monitor import TCPMonitor
 from f5_cccl.resource.ltm.pool import BigIPPool
 from f5_cccl.resource.ltm.virtual import VirtualServer
-from f5.bigip import BigIP
+
+from f5.bigip import ManagementRoot
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
-class CommonBigIP(BigIP):
+class CommonBigIP(ManagementRoot):
     """CommonBigIP class.
 
     Manages the resources for the partition(s) of the specified BIG-IP
@@ -42,8 +48,8 @@ class CommonBigIP(BigIP):
         token: The optional auth token to use with BIG-IP (e.g. "tmos")
     """
 
-    def __init__(self, hostname, port, username, password, partitions,
-                 token=None, manage_types=None):
+    def __init__(self, hostname, username, password, partition, prefix=None,
+                 port=443, token=None, manage_types=None):
         """Initialize the CommonBigIP object."""
         super_kwargs = {"port": port}
         if token:
@@ -54,7 +60,11 @@ class CommonBigIP(BigIP):
         self._port = port
         self._username = username
         self._password = password
-        self._partitions = partitions
+        self._partition = partition
+        self._prefix = ""
+
+        if prefix:
+            self._prefix = prefix
 
         # This currently hard codes what resources we care about until we
         # enable policy management.
@@ -69,31 +79,99 @@ class CommonBigIP(BigIP):
         self._manage_iapp = '/tm/sys/application/service' in manage_types
 
         # BIG-IP resources
-        self._virtuals = []
-        self._pools = []
-        self._polices = []
-        self._iapps = []
-        self._monitors = []
+        self._virtuals = dict()
+        self._pools = dict()
+        self._polices = dict()
+        self._iapps = dict()
+        self._monitors = dict()
 
     def refresh(self):
         """Refresh the internal cache with the BIG-IP state."""
-        new_pools = []
-        pools = self.ltm.pools.get_collection(
-            requests_params={"params": "expandSubcollections=true"})
+        partition_filter = "$filter=partition+eq+{}".format(self._partition)
 
-        for p in pools:
-            pool = BigIPPool(**p.__dict__)
-            new_pools.append(pool)
+        #  Retrieve the list of virtual servers in managed partition.
+        query = partition_filter
 
-        self._pools = new_pools
+        #  Retrieve the lists of health monitors
+        http_monitors = self.tm.ltm.monitor.https.get_collection(
+            requests_params={"params": query})
+        https_monitors = self.tm.ltm.monitor.https_s.get_collection(
+            requests_params={"params": query})
+        tcp_monitors = self.tm.ltm.monitor.tcps.get_collection(
+            requests_params={"params": query})
+        icmp_monitors = (
+            self.tm.ltm.monitor.gateway_icmps.get_collection(
+                requests_params={"params": query})
+        )
 
-        new_virtuals = []
-        virtuals = self.ltm.virtuals.get_collection()
+        #  Retrieve the list of pools in managed partition
+        query = "{}&expandSubcollections=true".format(partition_filter)
+        virtuals = self.tm.ltm.virtuals.get_collection(
+            requests_params={"params": query})
 
-        for v in virtuals:
-            virtual = VirtualServer(**v.__dict__)
-            new_virtuals.append(virtual)
+        pools = self.tm.ltm.pools.get_collection(
+            requests_params={"params": query})
 
-        self._virtuals = new_virtuals
+        #  Retrieve the list of policies in the managed partition
+        # policies = self.tm.ltm.policys.get_collection(
+        #    requests_params={"params": query})
+        self._virtuals = {
+            v.name: VirtualServer(**v.raw) for v in virtuals
+            if v.name.startswith(self._prefix)
+        }
 
-        # FIXME: Refresh iapps, monitors, and policies
+        #  Refresh the pool cache
+        self._pools = {
+            p.name: BigIPPool(**p.raw) for p in pools
+            if p.name.startswith(self._prefix)
+        }
+
+        #  Refresh the health monitor cache
+        self._monitors['http'] = {
+            m.name: HTTPMonitor(**m.raw) for m in http_monitors
+            if m.name.startswith(self._prefix)
+        }
+        self._monitors['https'] = {
+            m.name: HTTPSMonitor(**m.raw) for m in https_monitors
+            if m.name.startswith(self._prefix)
+        }
+        self._monitors['tcp'] = {
+            m.name: TCPMonitor(**m.raw) for m in tcp_monitors
+            if m.name.startswith(self._prefix)
+        }
+        self._monitors['icmp'] = {
+            m.name: ICMPMonitor(**m.raw) for m in icmp_monitors
+            if m.name.startswith(self._prefix)
+        }
+
+        # FIXME: Refresh iapps and policies
+
+    @property
+    def virtuals(self):
+        """Return the index of virtual servers."""
+        return self._virtuals
+
+    @property
+    def pools(self):
+        """Return the index of pools."""
+        return self._pools
+
+    @property
+    def http_monitors(self):
+        """Return the index of HTTP monitors."""
+        return self._monitors.get('http', dict())
+
+    @property
+    def tcp_monitors(self):
+        """Return the index of TCP monitors."""
+        return self._monitors.get('tcp', dict())
+
+    @property
+    def https_monitors(self):
+        """Return the index of HTTPS monitors."""
+        return self._monitors.get('https', dict())
+
+    @property
+    def icmp_monitors(self):
+        """Return the index of gateway ICMP monitors."""
+        return self._monitors.get('icmp', dict())


### PR DESCRIPTION
Problem:
Need to acquire virtual and healthmonitors to the BigIP
refresh function.

Convert bigip to use ManagementRoot instead of Deprecated BigIP

Analysis:
Adding more resource data to the refresh function.

Tests:
test/test_bigip.py