### PR TITLE
Reverted CRUD order.

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -16,3 +16,4 @@ PyYAML==3.12
 simplejson
 jsonschema
 python-coveralls==2.7.0
+requests==2.9.1


### PR DESCRIPTION
Problem:
 Change of CRUD ordering broke dependencies between these operations.

Solution:
 Revert back to original ordering of CRUD operations.

affects-branches: master, marathon-k8s-1.0