### PR TITLE
Fixed iapp_update call every interval.

### DIFF
--- a/f5_cccl/_f5.py
+++ b/f5_cccl/_f5.py
@@ -1344,6 +1344,21 @@ class CloudBigIP(BigIP):
 
         iapp_def = self.iapp_build_definition(config)
 
+        # Remove encrypted key and its value from SDK variables
+        for v in a.__dict__['variables']:
+            v.pop('encrypted', None)
+
+        no_variable_change = all(v in a.__dict__['variables'] for v in
+                                 iapp_def['variables'])
+        no_table_change = all(t in a.__dict__['tables'] for t in
+                              iapp_def['tables'])
+        no_option_change = all(config['iapp']['options'][k] == v for k, v in
+                               a.__dict__.iteritems() if k in
+                               config['iapp']['options'])
+
+        if no_variable_change and no_table_change and no_option_change:
+            return
+
         a.update(
             executeAction='definition',
             name=name,


### PR DESCRIPTION
Problem:
 iApps were being redeployed every verify interval since there was not
 any logic to check if an update should occur.

Solution:
 Add logic to update the iApp only when it needs to be.

Fixes: #81

affects-branches: master, marathon-k8s-1.0