### PR TITLE
Workaround for appsvcs integration iApps.

### DIFF
--- a/f5_cccl/_f5.py
+++ b/f5_cccl/_f5.py
@@ -1352,9 +1352,16 @@ class CloudBigIP(BigIP):
                                  iapp_def['variables'])
         no_table_change = all(t in a.__dict__['tables'] for t in
                               iapp_def['tables'])
-        no_option_change = all(config['iapp']['options'][k] == v for k, v in
-                               a.__dict__.iteritems() if k in
-                               config['iapp']['options'])
+        no_option_change = True
+        for k, v in a.__dict__.iteritems():
+            if k in config['iapp']['options']:
+                if config['iapp']['options'][k] != v:
+                    # FIXME (rtalley): description is overwritten in appsvcs
+                    # integration iApps this is a workaround until F5Networks/
+                    # f5-application-services-integration-iApp #43 is resolved
+                    if (k != 'description' and 'appsvcs_integration' in
+                            config['iapp']['template']):
+                        no_option_change = False
 
         if no_variable_change and no_table_change and no_option_change:
             return


### PR DESCRIPTION
Problem:
 appsvcs-integration-iApp templates overwrite the iappOptions
 description field which causes the controller to redeploy the iApp
 even though nothing has actually changed.

Solution:
 Have the controller ignore the description field if the iApp being
 configured is an appsvcs-integration template until
 F5Networks/f5-application-services-integration-iApp #43 is resolved.

Fixes: #91