### PR TITLE
Fix cccl import issue

### DIFF
--- a/f5_cccl/__init__.py
+++ b/f5_cccl/__init__.py
@@ -20,5 +20,3 @@ libraries that need to read, diff and apply configurations to a BIG-IP.
 """
 
 __version__ = '0.1.0'
-
-from .api import F5CloudServiceManager  # noqa: F401, F403

--- a/f5_cccl/service/test/test_config_reader.py
+++ b/f5_cccl/service/test/test_config_reader.py
@@ -18,7 +18,7 @@ import json
 import pickle
 import pytest
 
-from f5_cccl import F5CloudServiceManager
+from f5_cccl.api import F5CloudServiceManager
 from f5_cccl.bigip import CommonBigIP
 from f5_cccl.resource import ltm
 

--- a/f5_cccl/service/test/test_service_manager.py
+++ b/f5_cccl/service/test/test_service_manager.py
@@ -18,7 +18,7 @@ import json
 import pickle
 import pytest
 
-from f5_cccl import F5CloudServiceManager
+from f5_cccl.api import F5CloudServiceManager
 from f5_cccl.bigip import CommonBigIP
 from f5_cccl.resource import ltm
 


### PR DESCRIPTION
A recent change to the CCCL api.py file caused the pip install to not resolve the package dependencies.  Removing the import in the f5_cccl/__init__.py and making the api.py import explicit fixes the issue.
