### PR TITLE
Modify _f5.py to accept a list of pools

### DIFF
--- a/f5_cccl/_f5.py
+++ b/f5_cccl/_f5.py
@@ -354,7 +354,7 @@ class CloudBigIP(BigIP):
             # healthcheck add
             for mon in monitors:
                 if (mon['partition'] == partition and
-                    mon['name'] in healthcheck_add):
+                        mon['name'] in healthcheck_add):
                     self.healthcheck_create(partition, mon)
 
             # pool add
@@ -385,7 +385,7 @@ class CloudBigIP(BigIP):
             # healthcheck intersect
             for mon in monitors:
                 if (mon['partition'] == partition and
-                    mon['name'] in healthcheck_intersect):
+                        mon['name'] in healthcheck_intersect):
                     self.healthcheck_update(partition, mon['name'], mon)
 
             # pool intersection


### PR DESCRIPTION
Problem:
Pools and health monitors are currently nested under servers, but need
to be top-level objects.

Solution:
Moved the pools and health monitors out from servers into their own
dicts at the top level. Renamed 'services' to 'virtualServers' and
'policies' to 'l7Policies' to use the same names as cccl. There are
still some differences between this flattening effort and the cccl
schema, but they are beyond the scope of this story.

Fixes VEL-947

affects-branches: master