### PR TITLE
Add iApp support to service deployer

### DIFF
--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -90,14 +90,16 @@ class CommonBigIP(ManagementRoot):
         self._nodes = dict()
 
     def _manageable_resource(self, rsc):
-        """Resource will be managed if it matches prefix and does not belong
+        """Determine if the resource will be managed.
+
+        Resource will be managed if it matches prefix and does not belong
         to an appService (iApp)
 
         Args:
             rsc: A BIG-IP resource
         """
         return rsc.name.startswith(self._prefix) and \
-               getattr(rsc, 'appService', None) is None
+            getattr(rsc, 'appService', None) is None
 
     def refresh(self):
         """Refresh the internal cache with the BIG-IP state."""

--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -83,10 +83,21 @@ class CommonBigIP(ManagementRoot):
         # BIG-IP resources
         self._virtuals = dict()
         self._pools = dict()
+        self._all_pools = dict()
         self._policies = dict()
         self._iapps = dict()
         self._monitors = dict()
         self._nodes = dict()
+
+    def _manageable_resource(self, rsc):
+        """Resource will be managed if it matches prefix and does not belong
+        to an appService (iApp)
+
+        Args:
+            rsc: A BIG-IP resource
+        """
+        return rsc.name.startswith(self._prefix) and \
+               getattr(rsc, 'appService', None) is None
 
     def refresh(self):
         """Refresh the internal cache with the BIG-IP state."""
@@ -125,13 +136,18 @@ class CommonBigIP(ManagementRoot):
         #    requests_params={"params": query})
         self._virtuals = {
             v.name: IcrVirtualServer(**v.raw) for v in virtuals
-            if v.name.startswith(self._prefix)
+            if self._manageable_resource(v)
         }
 
         #  Refresh the pool cache
         self._pools = {
             p.name: IcrPool(**p.raw) for p in pools
-            if p.name.startswith(self._prefix)
+            if self._manageable_resource(p)
+        }
+
+        #  Refresh the all-pool cache
+        self._all_pools = {
+            p.name: IcrPool(**p.raw) for p in pools
         }
 
         #  Refresh the iapp cache
@@ -143,34 +159,36 @@ class CommonBigIP(ManagementRoot):
         #  Refresh the node cache
         self._nodes = {
             n.name: Node(**n.raw) for n in nodes
-            if n.name.startswith(self._prefix)
         }
 
         #  Refresh the health monitor cache
         self._monitors['http'] = {
             m.name: IcrHTTPMonitor(**m.raw) for m in http_monitors
-            if m.name.startswith(self._prefix)
+            if self._manageable_resource(m)
         }
         self._monitors['https'] = {
             m.name: IcrHTTPSMonitor(**m.raw) for m in https_monitors
-            if m.name.startswith(self._prefix)
+            if self._manageable_resource(m)
         }
         self._monitors['tcp'] = {
             m.name: IcrTCPMonitor(**m.raw) for m in tcp_monitors
-            if m.name.startswith(self._prefix)
+            if self._manageable_resource(m)
         }
         self._monitors['icmp'] = {
             m.name: IcrICMPMonitor(**m.raw) for m in icmp_monitors
-            if m.name.startswith(self._prefix)
+            if self._manageable_resource(m)
         }
 
     def get_virtuals(self):
         """Return the index of virtual servers."""
         return self._virtuals
 
-    def get_pools(self):
+    def get_pools(self, all_pools=False):
         """Return the index of pools."""
-        return self._pools
+        if all_pools:
+            return self._all_pools
+        else:
+            return self._pools
 
     def get_app_svcs(self):
         """Return the index of app services."""

--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -189,8 +189,7 @@ class CommonBigIP(ManagementRoot):
         """Return the index of pools."""
         if all_pools:
             return self._all_pools
-        else:
-            return self._pools
+        return self._pools
 
     def get_app_svcs(self):
         """Return the index of app services."""

--- a/f5_cccl/resource/ltm/app_service.py
+++ b/f5_cccl/resource/ltm/app_service.py
@@ -71,8 +71,8 @@ class ApplicationService(Resource):
                 # FIXME (rtalley): description is overwritten in appsvcs
                 # integration iApps this is a workaround until F5Networks/
                 # f5-application-services-integration-iApp #43 is resolved
-                if (key != 'description' or 'appsvcs_integration' not in
-                   self._data['template']):
+                if (key != 'description' or
+                        'appsvcs_integration' not in self._data['template']):
                     return False
         return True
 

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -357,14 +357,17 @@
       type: "object"
       properties:
         name:
+          description: "Specifies the table name"
           type: "string"
         columnNames:
+          description: "Specifies the table column names"
           type: "array"
           minItems: 1
           items:
             type: "string"
             minLength: 1
         rows:
+          description: "Specifies the table rows"
           type: "array"
           items:
             type: "array"
@@ -377,24 +380,42 @@
     iAppType:
       type: "object"
       properties:
-        partition:
-          type: "string"
+        name:
+          description: "Name of the Application Service object"
           minLength: 1
+          type: "string"
         template:
+          description: "The application service template path/name"
           type: "string"
           minLength: 1
         options:
           type: "object"
-          patternProperties:
-            "^[a-zA-Z0-9_-]+$":
+          properties:
+            description:
+              description: "Descriptive text that identifies the service"
+              type: "string"
+              minLength: 1
+            inheritedTrafficGroup:
+              description: "Inherit device group from current partition/pat"
+              type: "boolean"
+            inheritedDeviceGroup:
+              description: "Inherit traffic group from current partition/pat"
+              type: "boolean"
+            deviceGroup:
+              type: "string"
+              minLength: 1
+            trafficGroup:
               type: "string"
               minLength: 1
         tables:
+          description: "Specifies an array of tables, e.g. L7 policies, pool
+                       members"
           type: "array"
           patternProperties:
             "^[a-zA-Z0-9_-]+$":
               "$ref": "#/definitions/iappTableType"
         variables:
+          description: "Application-service specific name-value pairs"
           type  : "array"
           items:
             properties:
@@ -404,9 +425,8 @@
               value:
                 type: "string"
       required:
-      - partition
-      - template
-      - variables
+      - "template"
+      - "variables"
 
     virtualServerType: 
       id: "#/definitions/virtualServerType"

--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -1,10 +1,9 @@
 {
       "name": "test1",
-      "partition": "Project",
+      "partition": "test",
       "iapps": [{
         "name": "My App Service",
         "template": "/Common/f5.http",
-        "partition": "test_partition",
         "options": {"description": "This is a test iApp"},
         "tables": [{
           "name": "pool__members",

--- a/f5_cccl/service/config_reader.py
+++ b/f5_cccl/service/config_reader.py
@@ -24,6 +24,7 @@ from f5_cccl.resource.ltm.monitor.icmp_monitor import ApiICMPMonitor
 from f5_cccl.resource.ltm.monitor.tcp_monitor import ApiTCPMonitor
 from f5_cccl.resource.ltm.pool import ApiPool
 from f5_cccl.resource.ltm.virtual import ApiVirtualServer
+from f5_cccl.resource.ltm.app_service import ApplicationService
 
 
 class ServiceConfigReader(object):
@@ -79,6 +80,10 @@ class ServiceConfigReader(object):
 
         config_dict['policies'] = {}
 
-        config_dict['iapps'] = {}
+        iapps = service_config.get('iapps', list())
+        config_dict['iapps'] = {
+            i['name']: ApplicationService(partition=self._partition, **i)
+            for i in iapps
+        }
 
         return config_dict

--- a/f5_cccl/service/test/test_config_reader.py
+++ b/f5_cccl/service/test/test_config_reader.py
@@ -56,4 +56,4 @@ class TestServiceConfigReader:
         assert len(config.get('icmp_monitors')) == 1
         assert len(config.get('tcp_monitors')) == 1
         assert not len(config.get('policies'))
-        assert not len(config.get('iapps'))
+        assert len(config.get('iapps')) == 1

--- a/f5_cccl/test/conftest.py
+++ b/f5_cccl/test/conftest.py
@@ -201,11 +201,15 @@ class MockService():
 
     def load(self, name, partition):
         """Load a mock iapp."""
-        pass
+        return MockService()
 
     def create(self, name=None, template=None, partition=None, variables=None,
                tables=None, trafficGroup=None, description=None):
         """Create a mock iapp."""
+        pass
+
+    def delete(self):
+        """Delete the iapp object."""
         pass
 
 


### PR DESCRIPTION
Added iApps to service config deployer/builder and filtered
BIG-IP LTM objects that belong to iApps, because those are
managed by their parent iApp.