### PR TITLE
Adjust handling of pools in _f5.py

### DIFF
--- a/f5_cccl/testcommon.py
+++ b/f5_cccl/testcommon.py
@@ -32,6 +32,8 @@ class Pool(object):
         self.name = name
         self.monitor = kwargs.get('monitor', None)
         self.loadBalancingMode = kwargs.get('balance', None)
+        self.partition = kwargs.get('partition', None)
+        self.members = kwargs.get('members', None)
 
     def modify(self, **kwargs):
         """Placeholder: This will be mocked."""


### PR DESCRIPTION
Problem: With the introduction of multi-service ingress, a virtual could have multiple pools
instead of just one. This causes problems with the current flow in _f5.py involving pools being named
after the virtual, since there are now more pools with indexed names.

Solution: Adjust the handling of pools to check for the correct names. This requires partition to be part of the
pool dictionary, so partition doesn't need to be passed as a separate argument to create methods. It also requires
pool members to be within the pool config, not virtualServers.

Future controllers that pull in this fix will need to make sure that the pools field contains partition and members.