### PR TITLE
Fixes #103: Extend CCCL to support L7 policies

### DIFF
--- a/f5_cccl/resource/ltm/policy/__init__.py
+++ b/f5_cccl/resource/ltm/policy/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""This module implements the F5 CCCL Resource super class."""
+
+# Ignore import but unused flake error
+# flake8: noqa
+
+from .action import Action
+from .condition import Condition
+
+from .policy import Policy
+from .policy import IcrPolicy
+from .policy import ApiPolicy
+
+from .rule import Rule

--- a/f5_cccl/resource/ltm/policy/action.py
+++ b/f5_cccl/resource/ltm/policy/action.py
@@ -1,0 +1,94 @@
+"""Provides a class for managing BIG-IP L7 Rule Action resources."""
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+from f5_cccl.resource import Resource
+
+
+class Action(Resource):
+    """L7 Rule Action class."""
+    # The property names class attribute defines the names of the
+    # properties that we wish to compare.
+    properties = dict(
+        request=True,
+        pool=None,
+        location=None,
+        forward=False,
+        reset=False,
+        redirect=False
+    )
+
+    def __init__(self, name, data):
+        """Initialize the Action object.
+
+        Actions do not have explicit partition attributes, the are
+        implied by the partition of the rule to which they belong.
+        """
+        super(Action, self).__init__(name, partition=None)
+
+        # Actions are Only supported on requests.
+        self._data['request'] = True
+
+        # Is this a forwarding action?
+        if data.get('forward', False):
+
+            self._data['forward'] = True
+
+            # Yes, there are two supported forwarding actions:
+            # forward to pool and reset, these are mutually
+            # exclusive options.
+            pool = data.get('pool', None)
+            reset = data.get('reset', False)
+            if pool:
+                self._data['pool'] = pool
+            elif reset:
+                self._data['reset'] = reset
+
+        # Is this a redirect action?
+        elif data.get('redirect', False):
+            self._data['redirect'] = True
+
+            # Yes, set the location and httpReply attribute
+            self._data['location'] = data.get('location', None)
+            self._data['httpReply'] = data.get('httpReply', True)
+        else:
+            # Only forward and redirect are supported.
+            print("Unsupported action, must be one of forward, redirect, or "
+                  "reset.")
+            self._data.update(self.properties)
+
+    def __eq__(self, other):
+        """Check the equality of the two objects.
+
+        Do a straight data to data comparison.
+        """
+        if not isinstance(other, Action):
+            return False
+
+        return super(Action, self).__eq__(other)
+
+    def __str__(self):
+        return str(self._data)
+
+    def _uri_path(self, bigip):
+        """Return the URI path of an action object.
+
+        Not implemented because the current implementation does
+        not manage Actions individually."""
+        raise NotImplementedError

--- a/f5_cccl/resource/ltm/policy/action.py
+++ b/f5_cccl/resource/ltm/policy/action.py
@@ -59,7 +59,10 @@ class Action(Resource):
                 self._data['pool'] = pool
             elif reset:
                 self._data['reset'] = reset
-
+            else:
+                raise ValueError(
+                    "Unsupported forward action, must be one of reset or "
+                    "forward to pool.")
         # Is this a redirect action?
         elif data.get('redirect', False):
             self._data['redirect'] = True
@@ -69,9 +72,8 @@ class Action(Resource):
             self._data['httpReply'] = data.get('httpReply', True)
         else:
             # Only forward and redirect are supported.
-            print("Unsupported action, must be one of forward, redirect, or "
-                  "reset.")
-            self._data.update(self.properties)
+            raise ValueError("Unsupported action, must be one of forward, "
+                             "redirect, or reset.")
 
     def __eq__(self, other):
         """Check the equality of the two objects.

--- a/f5_cccl/resource/ltm/policy/condition.py
+++ b/f5_cccl/resource/ltm/policy/condition.py
@@ -22,7 +22,7 @@ from f5_cccl.resource import Resource
 
 
 class Condition(Resource):
-    """L7 Rule Action class."""
+    """L7 Rule Condition class."""
     # The property names class attribute defines the names of the
     # properties that we wish to compare.
     properties = {
@@ -92,6 +92,8 @@ class Condition(Resource):
                 'httpCookie': True, 'tmName': tm_name, 'values': values}
 
         else:
+            # This class does not support the condition type; however,
+            # we want to create in order to manage the policy.
             raise ValueError("Invalid match type must be one of: httpHost, "
                              "httpUri, httpHeader, or httpCookie")
 

--- a/f5_cccl/resource/ltm/policy/condition.py
+++ b/f5_cccl/resource/ltm/policy/condition.py
@@ -1,0 +1,128 @@
+"""Provides a class for managing BIG-IP L7 Rule Action resources."""
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+from f5_cccl.resource import Resource
+
+
+class Condition(Resource):
+    """L7 Rule Action class."""
+    # The property names class attribute defines the names of the
+    # properties that we wish to compare.
+    properties = {
+        "name": None,
+        "request": True,
+
+        "equals": None,
+        "endsWith": None,
+        "startsWith": None,
+        "contains": None,
+
+        "not": None,
+        "missing": None,
+        "caseSensitive": None,
+
+        "httpHost": False,
+        "host": False,
+
+        "httpUri": False,
+        "pathSegment": False,
+        "path": False,
+        "extension": False,
+        "index": None,
+
+        "httpHeader": False,
+        "httpCookie": False,
+
+        "tmName": None,
+        "values": list()
+    }
+
+    def __init__(self, name, data):
+        super(Condition, self).__init__(name, partition=None)
+
+        self._data['request'] = True
+
+        values = sorted(data.get('values', list()))
+        tm_name = data.get('tmName', None)
+        condition_map = dict()
+
+        # Does this rule match the HTTP hostname?
+        if data.get('httpHost', False):
+            condition_map = {'httpHost': True, 'host': True, 'values': values}
+
+        # Does this rule match a part of the HTTP URI?
+        elif data.get('httpUri', False):
+            condition_map = {'httpUri': True, 'values': values}
+            if data.get('path', False):
+                condition_map['path'] = True
+            elif data.get('pathSegment', False):
+                condition_map['pathSegment'] = True
+                condition_map['index'] = data.get('index', 1)
+            elif data.get('extension', False):
+                condition_map['extension'] = True
+            else:
+                raise ValueError("must specify one of path, pathSegment, or "
+                                 "extension for HTTP URI matching condition")
+
+        # Does this rule match an HTTP header?
+        elif data.get('httpHeader', False):
+            condition_map = {
+                'httpHeader': True, 'tmName': tm_name, 'values': values}
+
+        # Does this rule match an HTTP cookie?
+        elif data.get('httpCookie', False):
+            condition_map = {
+                'httpCookie': True, 'tmName': tm_name, 'values': values}
+
+        else:
+            raise ValueError("Invalid match type must be one of: httpHost, "
+                             "httpUri, httpHeader, or httpCookie")
+
+        self._data.update(condition_map)
+
+        # This condition attributes should not be set if they are not defined.
+        # For example, having a comparison option set to 'None' will conflict
+        # with the one that is set to 'True'
+        match_options = ['not', 'missing', 'caseSensitive']
+        comparisons = ['contains', 'equals', 'startsWith', 'endsWith']
+        for key in match_options + comparisons:
+            value = data.get(key, None)
+            if value:
+                self._data[key] = value
+
+    def __eq__(self, other):
+        """Check the equality of the two objects.
+
+        Do a data to data comparison as implemented in Resource.
+        """
+        if not isinstance(other, Condition):
+            return False
+
+        return super(Condition, self).__eq__(other)
+
+    def __str__(self):
+        return str(self._data)
+
+    def _uri_path(self, bigip):
+        """Return the URI path of an rule object.
+
+        Not implemented because the current implementation does
+        not manage Rules individually."""
+        raise NotImplementedError

--- a/f5_cccl/resource/ltm/policy/policy.py
+++ b/f5_cccl/resource/ltm/policy/policy.py
@@ -1,0 +1,198 @@
+"""Provides a class for managing BIG-IP L7 Policy resources."""
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from operator import itemgetter
+
+from f5_cccl.resource import Resource
+from f5_cccl.resource.ltm.policy.action import Action
+from f5_cccl.resource.ltm.policy.condition import Condition
+from f5_cccl.resource.ltm.policy.rule import Rule
+
+
+class Policy(Resource):
+    """L7 Policy class."""
+    # The property names class attribute defines the names of the
+    # properties that we wish to compare.
+    properties = dict(
+        name=None,
+        partition=None,
+        strategy="/Common/first-match",
+        rules=list()
+    )
+
+    def __init__(self, name, partition, **data):
+        """Create the policy and nested class objects"""
+        super(Policy, self).__init__(name, partition)
+
+        # Get the rules.
+        rules = data.get('rules', list())
+        self._data['rules'] = self._create_rules(
+            partition, rules)
+
+        self._data['strategy'] = data.get(
+            'strategy',
+            self.properties.get('strategy')
+        )
+
+        # Fix these values.
+        self._data['legacy'] = True
+        self._data['controls'] = ["forwarding"]
+        self._data['requires'] = ["http"]
+
+    def __eq__(self, other):
+        """Check the equality of the two objects.
+
+        Only compare the properties as defined in the
+        properties class dictionany.
+        """
+        if not isinstance(other, Policy):
+            return False
+
+        for key in self.properties:
+            if key == 'rules':
+                if len(self._data['rules']) != len(other.data['rules']):
+                    return False
+                for index, rule in enumerate(self._data['rules']):
+                    if rule != other.data['rules'][index]:
+                        return False
+                continue
+            if self._data[key] != other.data.get(key, None):
+                return False
+        return True
+
+    def __str__(self):
+        return str(self._data)
+
+    def _create_rules(self, partition, rules):
+        """Create a list of the policy Rules from rules data.
+
+        The order of the rules in the list is taken as the order
+        in which the should be evaluated.
+        """
+        new_rules = list()
+        for index, rule in enumerate(rules):
+            rule['ordinal'] = index
+            new_rules.append(Rule(partition=partition, **rule).data)
+
+        return new_rules
+
+    def _uri_path(self, bigip):
+        return bigip.tm.ltm.policys.policy
+
+
+class IcrPolicy(Policy):
+    """Policy object created from the iControl REST object"""
+    def __init__(self, name, partition, **data):
+        policy_data = self._flatten_policy(data)
+        super(IcrPolicy, self).__init__(name, partition, **policy_data)
+
+    def _flatten_policy(self, data):
+        """Flatten the unnecessary levels of nesting for the policy object.
+
+        The structure of a policy are returned by the SDK looks like:
+
+        'policy': {
+            ...,
+            'rulesReference': {
+                ...,
+                'items': [
+                    ...,
+                    'actionsReference': [
+                        ...,
+                        'items': [
+                            {action0}, {action1},...,{actionN}
+                        ]
+                    ],
+                    'rulesReference': [
+                        ...,
+                        'items': [
+                            {rule0}, {rule1},...,{ruleN}
+                        ]
+                    ]
+                ]
+            }
+        }
+
+        Flattens to a simpler representation:
+        'policy': {
+            ...,
+            'rules': {
+                ...,
+                'actions': [
+                     {action0}, {action1},...,{actionN}
+                 ]
+                 'rules': [
+                     {rule0}, {rule1},...,{ruleN}
+                 ]
+            }
+        }
+
+        This function does filter some of the Rule, Action, and Condition
+        properties.
+        """
+        policy = dict()
+        for key in Policy.properties:
+            if key == 'rules':
+                policy['rules'] = self._flatten_rules(
+                    data['rulesReference']['items'])
+            elif key == 'name' or key == 'partition':
+                pass
+            else:
+                policy[key] = data.get(key)
+        return policy
+
+    def _flatten_rules(self, rules_list):
+        rules = list()
+        for rule in sorted(rules_list, key=itemgetter('ordinal')):
+            flat_rule = dict()
+            for key in Rule.properties:
+                if key == 'actions':
+                    flat_rule['actions'] = self._flatten_actions(rule)
+                elif key == 'conditions':
+                    flat_rule['conditions'] = self._flatten_condition(rule)
+                else:
+                    flat_rule[key] = rule.get(key)
+            rules.append(flat_rule)
+        return rules
+
+    def _flatten_actions(self, rule):
+        actions = list()
+        actions_reference = rule.get('actionsReference', dict())
+
+        for action in actions_reference.get('items', list()):
+            flat_action = dict()
+            for key in Action.properties:
+                flat_action[key] = action.get(key)
+            actions.append(flat_action)
+        return actions
+
+    def _flatten_condition(self, rule):
+        conditions = list()
+        conditions_reference = rule.get('conditionsReference', dict())
+
+        for condition in conditions_reference.get('items', list()):
+            flat_condition = dict()
+            for key in Condition.properties:
+                flat_condition[key] = condition.get(key)
+            conditions.append(flat_condition)
+        return conditions
+
+
+class ApiPolicy(Policy):
+    """Policy object created from the API configuration object"""
+    pass

--- a/f5_cccl/resource/ltm/policy/rule.py
+++ b/f5_cccl/resource/ltm/policy/rule.py
@@ -47,7 +47,7 @@ class Rule(Resource):
         """Check the equality of the two objects.
 
         Only compare the properties as defined in the
-        properties class dictionany.
+        properties class dictionary.
         """
         if not isinstance(other, Rule):
             return False
@@ -80,9 +80,13 @@ class Rule(Resource):
         """
         new_actions = list()
 
+        unsupported_actions = 0
         for index, action in enumerate(actions):
-            name = "{}".format(index)
-            new_actions.append(Action(name, action))
+            name = "{}".format(index - unsupported_actions)
+            try:
+                new_actions.append(Action(name, action))
+            except ValueError:
+                unsupported_actions += 1
 
         return [action.data for action in sorted(new_actions)]
 
@@ -94,9 +98,13 @@ class Rule(Resource):
         """
         new_conditions = list()
 
+        unsupported_conditions = 0
         for index, condition in enumerate(conditions):
-            name = "{}".format(index)
-            new_conditions.append(Condition(name, condition))
+            name = "{}".format(index - unsupported_conditions)
+            try:
+                new_conditions.append(Condition(name, condition))
+            except ValueError:
+                unsupported_conditions += 1
 
         return [condition.data for condition in sorted(new_conditions)]
 

--- a/f5_cccl/resource/ltm/policy/rule.py
+++ b/f5_cccl/resource/ltm/policy/rule.py
@@ -1,0 +1,104 @@
+"""Provides a class for managing BIG-IP L7 Rule resources."""
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from functools import total_ordering
+
+from f5_cccl.resource import Resource
+from f5_cccl.resource.ltm.policy.action import Action
+from f5_cccl.resource.ltm.policy.condition import Condition
+
+
+@total_ordering
+class Rule(Resource):
+    """L7 Rule class"""
+    # The property names class attribute defines the names of the
+    # properties that we wish to compare.
+    properties = dict(
+        name=None,
+        ordinal=None,
+        actions=None,
+        conditions=None
+    )
+
+    def __init__(self, name, partition, **data):
+        super(Rule, self).__init__(name, partition)
+        self._data['ordinal'] = data.get('ordinal', 0)
+        self._data['actions'] = self._create_actions(
+            data.get('actions', list()))
+        self._data['conditions'] = self._create_conditions(
+            data.get('conditions', list()))
+
+    def __eq__(self, other):
+        """Check the equality of the two objects.
+
+        Only compare the properties as defined in the
+        properties class dictionany.
+        """
+        if not isinstance(other, Rule):
+            return False
+
+        for key in self.properties:
+            if key == 'actions' or key == 'conditions':
+                if len(self._data[key]) != len(other.data[key]):
+                    return False
+                for index, obj in enumerate(self._data[key]):
+                    if obj != other.data[key][index]:
+                        return False
+                continue
+            if self._data[key] != other.data.get(key, None):
+                return False
+
+        return True
+
+    def __str__(self):
+        return str(self._data)
+
+    def __lt__(self, other):
+        """Rich comparison function for sorting Rules."""
+        return self._data['ordinal'] < other.data['ordinal']
+
+    def _create_actions(self, actions):
+        """Return a new list of Actions data in sorted order.
+
+        The order of the list of actions is interpretted as
+        the order in which they should be applied.
+        """
+        new_actions = list()
+
+        for index, action in enumerate(actions):
+            name = "{}".format(index)
+            new_actions.append(Action(name, action))
+
+        return [action.data for action in sorted(new_actions)]
+
+    def _create_conditions(self, conditions):
+        """Return a new list of Conditions data in sorted order.
+
+        The order of the list of actions is interpretted as
+        the order in which they should be evaluated.
+        """
+        new_conditions = list()
+
+        for index, condition in enumerate(conditions):
+            name = "{}".format(index)
+            new_conditions.append(Condition(name, condition))
+
+        return [condition.data for condition in sorted(new_conditions)]
+
+    def _uri_path(self, bigip):
+        raise NotImplementedError

--- a/f5_cccl/resource/ltm/policy/test/bigip_policy.json
+++ b/f5_cccl/resource/ltm/policy/test/bigip_policy.json
@@ -1,0 +1,162 @@
+{
+  "status": "legacy",
+  "generation": 2600,
+  "rulesReference": {
+    "isSubcollection": true,
+    "link": "https://localhost/mgmt/tm/ltm/policy/~Test~wrapper_policy/rules?ver=12.1.1",
+    "items": [
+      {
+        "actionsReference": {
+          "isSubcollection": true,
+          "link": "https://localhost/mgmt/tm/ltm/policy/~Test~wrapper_policy/rules/~Test~my_rule1/actions?ver=12.1.1",
+          "items": [
+            {
+              "status": 0,
+              "selfLink": "https://localhost/mgmt/tm/ltm/policy/~Test~wrapper_policy/rules/~Test~my_rule1/actions/0?ver=12.1.1",
+              "kind": "tm:ltm:policy:rules:actions:actionsstate",
+              "code": 0,
+              "expirySecs": 0,
+              "generation": 2600,
+              "request": true,
+              "vlanId": 0,
+              "length": 0,
+              "poolReference": {
+                "link": "https://localhost/mgmt/tm/ltm/pool/~Test~pool1?ver=12.1.1"
+              },
+              "select": true,
+              "timeout": 0,
+              "offset": 0,
+              "forward": true,
+              "fullPath": "0",
+              "port": 0,
+              "pool": "/Test/pool1",
+              "name": "0"
+            }
+          ]
+        },
+        "ordinal": 0,
+        "kind": "tm:ltm:policy:rules:rulesstate",
+        "name": "my_rule1",
+        "selfLink": "https://localhost/mgmt/tm/ltm/policy/~Test~wrapper_policy/rules/~Test~my_rule1?ver=12.1.1",
+        "generation": 2600,
+        "fullPath": "/Test/my_rule1",
+        "partition": "Test",
+        "conditionsReference": {
+          "isSubcollection": true,
+          "link": "https://localhost/mgmt/tm/ltm/policy/~Test~wrapper_policy/rules/~Test~my_rule1/conditions?ver=12.1.1",
+          "items": [
+            {
+              "index": 0,
+              "all": true,
+              "caseInsensitive": true,
+              "name": "0",
+              "generation": 2600,
+              "contains": true,
+              "request": true,
+              "kind": "tm:ltm:policy:rules:conditions:conditionsstate",
+              "tmName": "X-Header",
+              "values": [
+                "openstack",
+                "velcro"
+              ],
+              "external": true,
+              "selfLink": "https://localhost/mgmt/tm/ltm/policy/~Test~wrapper_policy/rules/~Test~my_rule1/conditions/0?ver=12.1.1",
+              "remote": true,
+              "fullPath": "0",
+              "httpHeader": true,
+              "present": true
+            }
+          ]
+        }
+      },
+      {
+        "actionsReference": {
+          "isSubcollection": true,
+          "link": "https://localhost/mgmt/tm/ltm/policy/~Test~wrapper_policy/rules/~Test~my_rule2/actions?ver=12.1.1",
+          "items": [
+            {
+              "reset": true,
+              "status": 0,
+              "kind": "tm:ltm:policy:rules:actions:actionsstate",
+              "code": 0,
+              "expirySecs": 0,
+              "generation": 2600,
+              "request": true,
+              "vlanId": 0,
+              "length": 0,
+              "timeout": 0,
+              "offset": 0,
+              "forward": true,
+              "fullPath": "0",
+              "port": 0,
+              "selfLink": "https://localhost/mgmt/tm/ltm/policy/~Test~wrapper_policy/rules/~Test~my_rule2/actions/0?ver=12.1.1",
+              "name": "0"
+            }
+          ]
+        },
+        "ordinal": 1,
+        "kind": "tm:ltm:policy:rules:rulesstate",
+        "name": "my_rule2",
+        "generation": 2600,
+        "fullPath": "/Test/my_rule2",
+        "partition": "Test",
+        "selfLink": "https://localhost/mgmt/tm/ltm/policy/~Test~wrapper_policy/rules/~Test~my_rule2?ver=12.1.1"
+      }
+    ]
+  },
+  "references": {},
+  "fullPath": "/Test/wrapper_policy",
+  "kind": "tm:ltm:policy:policystate",
+  "name": "wrapper_policy",
+  "lastModified": "2017-06-14T13:53:28Z",
+  "partition": "Test",
+  "controls": [
+    "forwarding"
+  ],
+  "strategy": "/Common/first-match",
+  "_meta_data": {
+    "attribute_registry": {},
+    "reduction_forcing_pairs": [
+      [
+        "enabled",
+        "disabled"
+      ],
+      [
+        "online",
+        "offline"
+      ],
+      [
+        "vlansEnabled",
+        "vlansDisabled"
+      ]
+    ],
+    "container": null,
+    "exclusive_attributes": [],
+    "allowed_commands": [],
+    "read_only_attributes": [],
+    "allowed_lazy_attributes": [],
+    "uri": "https://10.1.0.170:443/mgmt/tm/ltm/policy/~Test~wrapper_policy/",
+    "required_json_kind": "tm:ltm:policy:policystate",
+    "bigip": null,
+    "icontrol_version": "",
+    "required_command_parameters": null,
+    "icr_session": null,
+    "required_load_parameters": null,
+    "required_creation_parameters": null,
+    "creation_uri_frag": "",
+    "object_has_stats": true,
+    "creation_uri_qargs": {
+      "ver": [
+        "12.1.1"
+      ]
+    },
+    "minimum_version": "11.5.0"
+  },
+  "requires": [
+    "http"
+  ],
+  "selfLink": "https://localhost/mgmt/tm/ltm/policy/~Test~wrapper_policy?ver=12.1.1",
+  "strategyReference": {
+    "link": "https://localhost/mgmt/tm/ltm/policy-strategy/~Common~first-match?ver=12.1.1"
+  }
+}

--- a/f5_cccl/resource/ltm/policy/test/test_action.py
+++ b/f5_cccl/resource/ltm/policy/test/test_action.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5_cccl.resource.ltm.policy import Action
+from mock import Mock
+import pytest
+
+
+@pytest.fixture
+def bigip():
+    bigip = Mock()
+    return bigip
+
+
+actions = {
+    'redirect': {
+	"request": True,
+	"redirect": True,
+	"location": "http://boulder-dev.f5.com",
+	"httpReply": True
+    },
+    'pool_forward': {
+	"request": True,
+	"forward": True,
+	"pool": "/Test/my_pool"
+    },
+    'reset': {
+	"request": True,
+	"forward": True,
+	"reset": True
+    },
+    'invalid_action': {
+        "request": False,
+        "forward": False,
+        "pool": None,
+        "location": None,
+        "reset": False,
+        "redirect": False
+    }
+}
+
+
+def test_create_redirect_action():
+    name="0"
+    action = Action(name, actions['redirect'])
+    data = action.data
+
+    assert action.name == "0"
+    assert not action.partition
+    assert data.get('request')
+    assert not data.get('forward')
+    assert not data.get('pool')
+    assert data.get('redirect')
+    assert data.get('location') == "http://boulder-dev.f5.com"
+    assert not data.get('reset')
+
+
+def test_create_pool_forwarding_action():
+    name="0"
+    action = Action(name, actions['pool_forward'])
+    data = action.data
+
+    assert action.name == "0"
+    assert not action.partition
+    assert data.get('request')
+    assert data.get('forward')
+    assert data.get('pool') == "/Test/my_pool"
+    assert not data.get('redirect')
+    assert not data.get('location')
+    assert not data.get('reset')
+
+
+def test_create_reset_action():
+    name="0"
+    action = Action(name, actions['reset'])
+    data = action.data
+
+    assert action.name == "0"
+    assert not action.partition
+    assert data.get('request')
+    assert data.get('forward')
+    assert not data.get('pool')
+    assert not data.get('redirect')
+    assert not data.get('location')
+    assert data.get('reset')
+
+
+def test_create_invalid_action():
+    name="0"
+    action = Action(name, actions['invalid_action'])
+    data = action.data
+
+    assert action.name == "0"
+    assert not action.partition
+    assert data.get('request')
+    assert not data.get('forward', True)
+    assert not data.get('pool', "test_pool")
+    assert not data.get('redirect', True)
+    assert not data.get('location', "test_uri")
+    assert not data.get('reset', True)
+
+
+def test_equal_actions():
+    name="0"
+    action_redirect_1 = Action(name, actions['redirect'])
+    action_redirect_2 = Action(name, actions['redirect'])
+
+    assert id(action_redirect_1) != id(action_redirect_2)
+    assert action_redirect_1 == action_redirect_2
+
+    action_redirect_1.data['location'] = "http://sea-dev.f5.com"
+    assert not action_redirect_1 == action_redirect_2
+    assert action_redirect_1 != action_redirect_2
+
+    fake_action = {
+        "request": False,
+        "forward": False,
+        "pool": None,
+        "location": None,
+        "reset": False,
+        "redirect": False
+    }
+
+    assert action_redirect_1 != fake_action
+    assert action_redirect_1 != actions['redirect']
+
+
+def test_str_action():
+    name="0"
+    action = Action(name, actions['redirect'])
+
+    assert str(action)
+
+
+def test_uri_path(bigip):
+    name="0"
+    action = Action(name, actions['redirect'])
+
+    with pytest.raises(NotImplementedError):
+        action._uri_path(bigip)

--- a/f5_cccl/resource/ltm/policy/test/test_action.py
+++ b/f5_cccl/resource/ltm/policy/test/test_action.py
@@ -42,6 +42,11 @@ actions = {
 	"forward": True,
 	"reset": True
     },
+    'virtual_forward': {
+        "request": True,
+        "forward": True,
+        "virtual": "/Test/my_virtual"
+    },
     'invalid_action': {
         "request": False,
         "forward": False,
@@ -100,17 +105,16 @@ def test_create_reset_action():
 
 def test_create_invalid_action():
     name="0"
-    action = Action(name, actions['invalid_action'])
-    data = action.data
 
-    assert action.name == "0"
-    assert not action.partition
-    assert data.get('request')
-    assert not data.get('forward', True)
-    assert not data.get('pool', "test_pool")
-    assert not data.get('redirect', True)
-    assert not data.get('location', "test_uri")
-    assert not data.get('reset', True)
+    with pytest.raises(ValueError):
+        action = Action(name, actions['invalid_action'])
+
+
+def test_create_vs_forward_action():
+    name="0"
+
+    with pytest.raises(ValueError):
+        action = Action(name, actions['virtual_forward'])
 
 
 def test_equal_actions():

--- a/f5_cccl/resource/ltm/policy/test/test_condition.py
+++ b/f5_cccl/resource/ltm/policy/test/test_condition.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5_cccl.resource.ltm.policy import Condition
+from mock import Mock
+import pytest
+
+
+conditions = {
+    'http_host': {
+        'httpHost': True,
+        'host': True,
+        'equals': True,
+        'values': ["www.my-site.com", "www.your-site.com"],
+    },
+    'http_uri_path': {
+        'httpUri': True,
+        'path': True,
+        'not': True,
+        'equals': True,
+        'values': ["/", "/home.htm"]
+    },
+    'http_uri_path_segment': {
+        'httpUri': True,
+        'pathSegment': True,
+        'index': 2,
+        'startsWith': True,
+        'values': ["articles"],
+    },
+    'http_uri_extension': {
+        'httpUri': True,
+        'extension': True,
+        'startsWith': True,
+        'values': ["htm"]
+    },
+    'http_uri_unsupported': {
+        'httpUri': True,
+        'queryString': True,
+        'equals': True,
+        'values': ["expandSubcollections=true"]
+    },
+    'http_unsupported_operand_type': {
+        'httpMethod': True,
+        'equals': True,
+        'values': ["GET"]
+    },
+    'http_cookie': {
+        'httpCookie': True,
+        'tmName': "Cookie",
+        'contains': True,
+        'values': ["sessionToken=abc123"]
+    },
+    'http_header': {
+        'httpHeader': True,
+        'tmName': "Host",
+        'contains': True,
+        'values': ["www.acme.com"]
+    }
+}
+
+
+@pytest.fixture
+def bigip():
+    bigip = Mock()
+    return bigip
+
+
+def test_create_http_host_match():
+    name="0"
+    condition = Condition(name, conditions['http_host'])
+    data = condition.data
+
+    assert condition.name == "0"
+    assert not condition.partition
+    assert data.get('httpHost')
+    assert data.get('host')
+    assert data.get('equals')
+    assert data.get('values') == ["www.my-site.com",
+                                  "www.your-site.com"]
+
+    assert not data.get('startsWith')
+    assert not data.get('endsWith')
+    assert not data.get('contains')
+
+    assert 'httpUri' not in data
+    assert 'httpCookie' not in data
+    assert 'httpHeader' not in data
+
+    assert not data.get('index')
+    assert not data.get('path')
+    assert not data.get('pathSegment')
+    assert not data.get('extension')
+    assert not data.get('httpCookie')
+    assert not data.get('httpHeader')
+    assert not data.get('tmName')
+
+
+def test_create_http_uri_path_match():
+    name="0"
+    condition = Condition(name, conditions['http_uri_path'])
+    data = condition.data
+
+    assert condition.name == "0"
+    assert not condition.partition
+
+    assert data.get('httpUri')
+    assert data.get('path')
+    assert data.get('values') == ["/", "/home.htm"]
+
+    assert 'httpHost' not in data
+    assert 'httpCookie' not in data
+    assert 'httpHeader' not in data
+
+    assert data.get('equals')
+    assert not data.get('startsWith')
+    assert not data.get('endsWith')
+    assert not data.get('contains')
+
+    assert not data.get('missing')
+    assert data.get('not')
+    assert not data.get('caseSensitive')
+
+    assert not data.get('index')
+    assert not data.get('pathSegment')
+    assert not data.get('extension')
+    assert not data.get('httpCookie')
+    assert not data.get('httpHeader')
+    assert not data.get('tmName')
+
+
+def test_create_http_uri_unsupported_match():
+    name="0"
+
+    with pytest.raises(ValueError):
+        condition = Condition(name, conditions['http_uri_unsupported'])
+
+
+def test_create_http_unsupported_operand_type():
+    name="0"
+    with pytest.raises(ValueError):
+        condition = Condition(name, conditions['http_unsupported_operand_type'])
+
+
+def test_create_http_uri_path_segment_match():
+    name="0"
+    condition = Condition(name, conditions['http_uri_path_segment'])
+    data = condition.data
+
+    assert condition.name == "0"
+    assert not condition.partition
+
+    assert data.get('httpUri')
+    assert data.get('pathSegment')
+    assert data.get('values') == ["articles"]
+    assert data.get('index') == 2
+
+    assert 'httpHost' not in data
+    assert 'httpCookie' not in data
+    assert 'httpHeader' not in data
+
+    assert not data.get('equals')
+    assert data.get('startsWith')
+    assert not data.get('endsWith')
+    assert not data.get('contains')
+
+    assert not data.get('missing')
+    assert not data.get('not')
+    assert not data.get('caseSensitive')
+
+    assert not data.get('path')
+    assert not data.get('extension')
+    assert not data.get('httpCookie')
+    assert not data.get('httpHeader')
+    assert not data.get('tmName')
+
+
+def test_create_http_uri_extension_match():
+    name="0"
+    condition = Condition(name, conditions['http_uri_extension'])
+    data = condition.data
+
+    assert condition.name == "0"
+    assert not condition.partition
+
+    assert data.get('httpUri')
+    assert data.get('extension')
+    assert data.get('values') == ["htm"]
+
+    assert 'httpHost' not in data
+    assert 'httpCookie' not in data
+    assert 'httpHeader' not in data
+
+    assert not data.get('equals')
+    assert data.get('startsWith')
+    assert not data.get('endsWith')
+    assert not data.get('contains')
+
+    assert not data.get('missing')
+    assert not data.get('not')
+    assert not data.get('caseSensitive')
+
+    assert not data.get('index')
+    assert not data.get('path')
+    assert not data.get('pathSegment')
+    assert not data.get('httpCookie')
+    assert not data.get('httpHeader')
+    assert not data.get('tmName')
+
+
+def test_create_http_cookie_match():
+    name="0"
+    condition = Condition(name, conditions['http_cookie'])
+    data = condition.data
+
+    assert condition.name == "0"
+    assert not condition.partition
+
+    assert data.get('httpCookie')
+    assert data.get('tmName') == "Cookie"
+    assert data.get('values') == ["sessionToken=abc123"]
+
+    assert 'httpHost' not in data
+    assert 'httpUri' not in data
+    assert 'httpHeader' not in data
+
+    assert not data.get('equals')
+    assert not data.get('startsWith')
+    assert not data.get('endsWith')
+    assert data.get('contains')
+
+    assert not data.get('missing')
+    assert not data.get('not')
+    assert not data.get('caseSensitive')
+
+    assert not data.get('index')
+    assert not data.get('path')
+    assert not data.get('pathSegment')
+
+
+def test_create_http_header_match():
+    name="0"
+    condition = Condition(name, conditions['http_header'])
+    data = condition.data
+
+    assert condition.name == "0"
+    assert not condition.partition
+
+    assert data.get('httpHeader')
+    assert data.get('tmName') == "Host"
+    assert data.get('values') == ["www.acme.com"]
+
+    assert 'httpHost' not in data
+    assert 'httpUri' not in data
+    assert 'httpCookie' not in data
+
+    assert not data.get('equals')
+    assert not data.get('startsWith')
+    assert not data.get('endsWith')
+    assert data.get('contains')
+
+    assert not data.get('missing')
+    assert not data.get('not')
+    assert not data.get('caseSensitive')
+
+    assert not data.get('index')
+    assert not data.get('path')
+    assert not data.get('pathSegment')
+
+
+def test_equal_conditions():
+    name="0"
+    condition_1 = Condition(name, conditions['http_host'])
+    condition_2 = Condition(name, conditions['http_host'])
+
+    assert id(condition_1) != id(condition_2)
+    assert condition_1 == condition_2
+
+    condition_1.data['values'].pop()
+
+    assert not condition_1 == condition_2
+    assert condition_1 != condition_2
+
+    fake_condition = {
+        "httpHost": False,
+        "values": ["www.my-site.com"]
+    }
+
+    assert condition_1 != fake_condition
+    assert condition_1 != conditions['http_uri_path']
+
+
+def test_str_condition():
+    name="0"
+    condition = Condition(name, conditions['http_host'])
+
+    assert str(condition)
+
+
+def test_uri_path(bigip):
+    name="0"
+    condition = Condition(name, conditions['http_host'])
+
+    with pytest.raises(NotImplementedError):
+        condition._uri_path(bigip)

--- a/f5_cccl/resource/ltm/policy/test/test_policy.py
+++ b/f5_cccl/resource/ltm/policy/test/test_policy.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from copy import deepcopy
+import os
+
+import json
+from mock import Mock
+from pprint import pprint as pp
+import pytest
+
+from f5_cccl.resource.ltm.policy import IcrPolicy
+from f5_cccl.resource.ltm.policy import Policy
+
+
+@pytest.fixture
+def bigip():
+    bigip = Mock()
+    return bigip
+
+
+@pytest.fixture
+def icr_policy_dict():
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    policy_file = os.path.join(current_dir, "bigip_policy.json")
+    with open(policy_file, "r") as fp:
+        json_data = fp.read()
+
+    return json.loads(json_data)
+
+
+@pytest.fixture
+def api_policy():
+    test_policy = {
+        'name': "wrapper_policy",
+        'strategy': "/Common/first-match",
+        'rules': [{
+            'name': "my_rule1",
+            'actions': [{
+                'pool': "/Test/pool1",
+                'forward': True,
+                'request': True
+            }],
+            'conditions': [{
+                "httpHeader": True,
+                "contains": True,
+                "tmName": "X-Header",
+                "values": ["openstack", "velcro"]
+            }]
+        },
+        {
+            'name': "my_rule2",
+            'actions': [{'reset': True, 'forward': True}],
+            'conditions': []
+        }]
+    }
+
+    return Policy(partition="Test", **test_policy)
+
+
+@pytest.fixture
+def policy_0():
+    data = {
+        'name': "my_policy",
+        'partition': "Test",
+        'strategy': "/Common/first-match",
+        'rules': []
+    }
+    return Policy(**data)
+
+
+def test_create_policy():
+    data = {
+        'name': "my_policy",
+        'partition': "Test",
+        'strategy': "/Common/first-match",
+        'rules': []
+    }
+    policy = Policy(**data)
+
+    assert policy.name == "my_policy"
+    assert policy.partition == "Test"
+
+    assert policy.data.get('strategy') == "/Common/first-match"
+    assert len(policy.data.get('rules')) == 0
+    assert policy.data.get('legacy')
+    assert policy.data.get('controls') == ["forwarding"]
+    assert policy.data.get('requires') == ["http"]
+
+    rules = {'name': "test_rule",
+             'actions': [],
+             'conditions': []}
+    data['rules'].append(rules)
+
+    policy = Policy(**data)
+    assert policy.name == "my_policy"
+    assert policy.partition == "Test"
+
+    assert policy.data.get('strategy') == "/Common/first-match"
+    assert len(policy.data.get('rules')) == 1
+    assert policy.data.get('legacy')
+    assert policy.data.get('controls') == ["forwarding"]
+    assert policy.data.get('requires') == ["http"]
+
+
+def test_uri_path(bigip, policy_0):
+    assert (policy_0._uri_path(bigip) ==
+            bigip.tm.ltm.policys.policy)
+
+
+def test_compare_policy(policy_0):
+
+    policy_1 = deepcopy(policy_0)
+
+    assert policy_0 == policy_1
+
+    rules = {'name': "test_rule",
+             'actions': [],
+             'conditions': []}
+    policy_0.data['rules'].append(rules)
+
+    assert policy_0 != policy_1
+
+    rules = {'name': "prod_rule",
+             'actions': [],
+             'conditions': []}
+    policy_1.data['rules'].append(rules)
+
+    assert policy_0 != policy_1
+
+    policy_2 = deepcopy(policy_0)
+    assert policy_0 == policy_2
+
+    policy_2.data['name'] = "your_policy"
+    assert not policy_0 == policy_2
+
+def test_compare_policy_w_dict(policy_0):
+    data = {
+        'name': "my_policy",
+        'partition': "Test",
+        'strategy': "/Common/first-match",
+        'rules': []
+    }
+    assert policy_0 != data
+
+
+def test_tostring(policy_0):
+    assert str(policy_0) != ""
+
+
+def test_create_policy_from_bigip(icr_policy_dict):
+    policy = IcrPolicy(**icr_policy_dict)
+
+    assert policy.name == "wrapper_policy"
+    assert policy.partition == "Test"
+
+    data = policy.data
+    assert data.get('strategy') == "/Common/first-match"
+    assert len(data.get('rules')) == 2
+    assert data.get('legacy')
+    assert data.get('controls') == ["forwarding"]
+    assert data.get('requires') == ["http"]
+
+
+def test_compare_icr_to_api_policy(icr_policy_dict, api_policy):
+    icr_policy = IcrPolicy(**icr_policy_dict)
+    assert icr_policy == api_policy

--- a/f5_cccl/resource/ltm/policy/test/test_rule.py
+++ b/f5_cccl/resource/ltm/policy/test/test_rule.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5_cccl.resource.ltm.policy import Rule
+from mock import Mock
+import pytest
+
+
+@pytest.fixture
+def bigip():
+    bigip = Mock()
+    return bigip
+
+
+action_0 = {
+    "request": True,
+    "redirect": True,
+    "location": "http://boulder-dev.f5.com",
+    "httpReply": True
+}
+
+action_1 = {
+    "request": True,
+    "redirect": True,
+    "location": "http://seattle-dev.f5.com",
+    "httpReply": True
+}
+
+condition_0 = {
+    'httpUri': True,
+    'pathSegment': True,
+    'contains': True,
+    'values': ["colorado"],
+}
+
+condition_1 = {
+    'httpUri': True,
+    'pathSegment': True,
+    'contains': True,
+    'values': ["washington"],
+}
+
+
+@pytest.fixture
+def rule_0():
+    data = {'ordinal': "0",
+            'actions': [],
+            'conditions': []}
+    data['conditions'].append(condition_0)
+    data['actions'].append(action_0)
+    return Rule(name="rule_0", partition="Test", **data)
+
+
+@pytest.fixture
+def rule_0_clone():
+    data = {'ordinal': "0",
+            'actions': [],
+            'conditions': []}
+    data['conditions'].append(condition_0)
+    data['actions'].append(action_0)
+    return Rule(name="rule_0", partition="Test", **data)
+
+
+@pytest.fixture
+def rule_1():
+    data = {'ordinal': "1",
+            'actions': [],
+            'conditions': []}
+    data['conditions'].append(condition_1)
+    data['actions'].append(action_1)
+    return Rule(name="rule_1", partition="Test", **data)
+
+
+@pytest.fixture
+def rule_no_actions():
+    data = {'ordinal': "0",
+            'actions': [],
+            'conditions': []}
+    data['conditions'].append(condition_1)
+    return Rule(name="rule_1", partition="Test", **data)
+
+
+@pytest.fixture
+def rule_no_conditions():
+    data = {'ordinal': "0",
+            'actions': [],
+            'conditions': []}
+    data['actions'].append(action_1)
+    return Rule(name="rule_1", partition="Test", **data)
+
+
+def test_create_rule():
+    data = {'ordinal': "0",
+            'actions': [],
+            'conditions': []}
+
+    rule = Rule(name="rule_0", partition="Test", **data)
+
+    assert rule.name == "rule_0"
+    assert rule.partition == "Test"
+    assert len(rule.data['conditions']) == 0
+    assert len(rule.data['actions']) == 0
+
+    data['conditions'].append(condition_0)
+    data['actions'].append(action_0)
+
+    rule = Rule(name="rule_1", partition="Test", **data)
+    assert len(rule.data['conditions']) == 1
+    assert len(rule.data['actions']) == 1
+
+
+def test_uri_path(bigip, rule_0):
+    with pytest.raises(NotImplementedError):
+        rule_0._uri_path(bigip)
+
+
+def test_less_than(rule_0, rule_1):
+    assert rule_0 < rule_1
+
+
+def test_tostring(rule_0):
+    assert str(rule_0) != ""
+
+
+def test_compare_rules(rule_0, rule_0_clone, rule_1,
+                       rule_no_actions, rule_no_conditions):
+
+    assert rule_0 == rule_0_clone
+    assert rule_0 != rule_1
+    assert rule_0 != rule_no_actions
+    assert rule_0 != rule_no_conditions
+
+    fake_rule = {'ordinal': "0",
+                 'actions': [],
+                 'conditions': []}
+
+    assert rule_0 != fake_rule
+
+    rule_0_clone.data['actions'][0]['location'] = \
+        "http://seattle-dev.f5.com"
+
+    assert rule_0 != rule_0_clone

--- a/f5_cccl/resource/ltm/policy/test/test_rule.py
+++ b/f5_cccl/resource/ltm/policy/test/test_rule.py
@@ -39,6 +39,12 @@ action_1 = {
     "httpReply": True
 }
 
+action_2 = {
+    "request": True,
+    "forward": True,
+    "virtual": "/Test/my_virtual"
+}
+
 condition_0 = {
     'httpUri': True,
     'pathSegment': True,
@@ -53,6 +59,12 @@ condition_1 = {
     'values': ["washington"],
 }
 
+condition_2 = {
+    'httpUri': True,
+    'queryString': True,
+    'contains': True,
+    'values': ["washington"],
+}
 
 @pytest.fixture
 def rule_0():
@@ -89,8 +101,8 @@ def rule_no_actions():
     data = {'ordinal': "0",
             'actions': [],
             'conditions': []}
-    data['conditions'].append(condition_1)
-    return Rule(name="rule_1", partition="Test", **data)
+    data['conditions'].append(condition_0)
+    return Rule(name="rule_0", partition="Test", **data)
 
 
 @pytest.fixture
@@ -121,6 +133,25 @@ def test_create_rule():
     assert len(rule.data['conditions']) == 1
     assert len(rule.data['actions']) == 1
 
+    data['conditions'] = [condition_2]
+    data['actions'] = [action_0]
+
+    rule = Rule(name="rule_1", partition="Test", **data)
+    assert len(rule.data['conditions']) == 0
+    assert len(rule.data['actions']) == 1
+
+    data['conditions'].append(condition_0)
+    rule = Rule(name="rule_1", partition="Test", **data)
+    assert len(rule.data['conditions']) == 1
+    assert len(rule.data['actions']) == 1
+
+    data['conditions'] = [condition_0]
+    data['actions'] = [action_2]
+
+    rule = Rule(name="rule_1", partition="Test", **data)
+    assert len(rule.data['conditions']) == 1
+    assert len(rule.data['actions']) == 0
+
 
 def test_uri_path(bigip, rule_0):
     with pytest.raises(NotImplementedError):
@@ -140,6 +171,7 @@ def test_compare_rules(rule_0, rule_0_clone, rule_1,
 
     assert rule_0 == rule_0_clone
     assert rule_0 != rule_1
+
     assert rule_0 != rule_no_actions
     assert rule_0 != rule_no_conditions
 

--- a/f5_cccl/resource/resource.py
+++ b/f5_cccl/resource/resource.py
@@ -57,10 +57,9 @@ class Resource(object):
             name (string): the name of the resource
             partition (string): the resource partition
         """
-        if not name or not partition:
+        if not name:
             raise ValueError(
-                "must have at least name({}) and partition({})".format(
-                    name, partition))
+                "must have at least name({})".format(name))
 
         self._data = dict()
         self._data['name'] = name

--- a/f5_cccl/resource/test/test_resource.py
+++ b/f5_cccl/resource/test/test_resource.py
@@ -75,15 +75,21 @@ def test_create_resource_with_data():
 def test_create_resource_without_name():
     u"""Test Resource instantiation without name."""
     with pytest.raises(ValueError):
-        res = Resource(name=None,
-                       partition=resource_data()['partition'])
+        res = Resource(name=None, partition=None)
 
 
 def test_create_resource_without_partition():
     u"""Test Resource instantiation without name."""
-    with pytest.raises(ValueError):
-        res = Resource(name=resource_data()['name'],
-                       partition=None)
+    data = resource_data()
+    name = data.get('name', "")
+    partition = data.get('partition', "")
+
+    res = Resource(name=name, partition=None)
+
+    assert res
+    assert res.name == name
+    assert not res.partition
+    assert res.data
 
 
 def test_get_uri_path(bigip):

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -88,7 +88,7 @@
             type: "array"
         conditions: 
           items: 
-            $ref: "#definitions/l7RuleMatchType"
+            $ref: "#definitions/l7ConditionType"
             type: "array"
       required:
         - "name"
@@ -96,85 +96,146 @@
     l7RuleActionType: 
       type: "object"
       properties: 
-        action: 
-          default: "forward-pool"
-          description: |
-            "Either a forwarding, redirect, or reject action to take. 
-            Supported actions are:
-              forward-pool: Forward to the named pool.  The
-              pool must exist in the managed partition or the
-              Common partition.
-
-              forward-vs: Forward to the named virtual server.
-              The virtual server must exist in the managed partition 
-              or the Common partition.
-
-              redirect-uri: Redirect to the URI string
-
-              reject: Block the traffic"
-          enum: 
-            - "forward-vs"
-            - "forward-pool"
-            - "redirect-uri"
-            - "reject"
+        forward:
+          type: "boolean"
+          description: "This action will affect forwarding."
+          default: True
+        request:
+          type: "boolean"
+          description: "This policy action is performed on connection requests."
+          default: True
+        reset:
+          type: "boolean"
+          description: "This action will reset a connection."
+          default: False
+        pool:
+          description: "This action will direct the stream to this pool."
           type: "string"
-
-        target: 
-          description: |
-            "Where to forward the request.  This must be defined for 
-            all forwarding rules."
+        redirect:
+          type: "boolean"
+          description: "This action will redirect the request."
+          default: False
+        location:
           type: "string"
-          minLength: 1
-          maxLength: 256
+          description: "This action will come from the given location."
+        httpReply:
+          type: "boolean"
+          description: "This action will affect a reply to a given HTTP request."
+          default: False
 
-      required: 
-        - "action"
+      oneOf:
+        - required:
+          - "forward"
+          - "request"
+          - "pool"
+        - required:
+          - "forward"
+          - "request"
+          - "reset"
+        - required:
+          - "request"
+          - "redirect"
+          - "location"
+          - "httpReply"
 
-    l7RuleMatchType: 
+    l7ConditionType:
       type: "object"
-      properties: 
+      properties:
+
+        # Match modifiers
         caseSensitive: 
           default: false
           description: "The match string is case-sensive"
           type: "boolean"
-        condition: 
-          description: "."
-          enum: 
-            - "equals"
-            - "begins-with"
-            - "ends-with"
-            - "contains"
-          type: "string"
         missing: 
           default: false
           description: "Skip this condition if it is missing from the request."
           type: "boolean"
-        negate: 
+        not:
           default: false
           description: "Negate the sense of the match."
           type: "boolean"
-        operand: 
-          description: "Request object to evaluate."
-          enum: 
-            - "http-uri-host"
-            - "http-uri-path"
-            - "http-uri-ext"
-            - "http-header"
-            - "http-cookie"
-          type: "string"
-        cookieName: 
+
+        # Match types
+        equals:
+          type: "boolean"
+        startsWith:
+          type: "boolean"
+        endsWith:
+          type: "boolean"
+        contains:
+          type: "boolean"
+
+        # Operand types
+        httpUri:
+          description: "Match agains the httpUri."
+          type: "boolean"
+        httpHost:
+          description: "Match the HTTP hostname."
+          type: "boolean"
+        httpCookie:
           description: "Name of the HTTP cookie that contains the value to compare."
-          type: "string"
-        httpHeaderName: 
+          type: "boolean"
+        httpHeader:
           description: "Name of the HTTP header that contains the value to compare."
+          type: "boolean"
+
+        # Operand values
+        tmName:
+          description: "The matched operand name."
           type: "string"
-        value: 
-          description: "Value against which the operand is compared."
-          type: "string"
-      required: 
-        - "operand"
-        - "condition"
-        - "value"
+        values:
+          description: "List of values against which the operand is compared."
+          items:
+            type: "string"
+          type: "array"
+
+        host:
+          description: "Matches a host"
+          type: "boolean"
+          default: true
+        extension:
+          description: "Matches an extension(URI file type)."
+          type: "boolean"
+          default: true
+        path:
+          description: "Matches an extension(URI path)."
+          type: "boolean"
+          default: true
+        pathSegment:
+          description: "Matches an extension(URI path segment)."
+          type: "boolean"
+          default: true
+        index:
+          description: "The specified index is used to match a specific segment."
+          type: "integer"
+
+      oneOf:
+        - required:
+            - "httpUri"
+            - "values"
+            - "extension"
+        - required:
+            - "httpUri"
+            - "values"
+            - "path"
+        - required:
+            - "httpUri"
+            - "values"
+            - "index"
+            - "pathSegment"
+        - required:
+            - "httpHost"
+            - "host"
+            - "values"
+        - required:
+            - "httpHeader"
+            - "values"
+            - "tmName"
+        - required:
+            - "httpCookie"
+            - "values"
+            - "tmName"
 
     l7PolicyType: 
       id: "#/definitions/l7PolicyType"
@@ -183,27 +244,26 @@
         name: 
           type: "string"
           description: "Name of the policy object"
-        description: 
-          type: "string"
         strategy: 
           type: "string"
           description: |
             "Specifies the method to determine which actions get executed in the
             case where there are multiple rules that match. The default is first."
           enum:
-            - "first"
-            - "best"
-            - "all"
-          default: "first"
+            - "/Common/first-match"
+            - "/Common/best-match"
+            - "/Common/all-match"
+          default: "/Common/first-match"
         rules: 
-          type: "array"
-          description: |
-            "List of rules associated with this policy.  This can be an empty list"
           items:
+            type: "array"
+            description: |
+              "List of rules associated with this policy.  This can be an empty list"
             $ref: "#definitions/l7RuleType"
       required: 
         - "name"
         - "rules"
+      additionalProperties: "false"
 
     healthMonitorType: 
       type: "object"

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -168,7 +168,7 @@
 
         # Operand types
         httpUri:
-          description: "Match agains the httpUri."
+          description: "Match against the httpUri."
           type: "boolean"
         httpHost:
           description: "Match the HTTP hostname."

--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -1,46 +1,46 @@
 {
-      "name": "test1",
-      "partition": "test",
-      "iapps": [{
-        "name": "My App Service",
-        "template": "/Common/f5.http",
-        "options": {"description": "This is a test iApp"},
-        "tables": [{
-          "name": "pool__members",
-          "columnNames": ["addr", "port", "connection_limit"],
-          "rows": [{"row": ["1.2.3.4", "30001", "0"]},
-                   {"row": ["1.2.3.4", "30002", "0"]},
-                   {"row": ["1.2.3.4", "30003", "0"]},
-                   {"row": ["1.2.3.4", "30004", "0"]},
-                   {"row": ["1.2.3.4", "30005", "0"]}]
-          }
-        ],        
-        "variables": [
-          {"name": "net__client_mode", "value": "wan"},
-          {"name": "net__server_mode", "value": "lan"},
-          {"name": "pool__addr", "value": "10.10.1.100"},
-          {"name": "pool__port", "value": "80"},
-          {"name": "pool__pool_to_use", "value": "/#create_new#"},
-          {"name": "pool__lb_method", "value": "round-robin"},
-          {"name": "pool__http", "value": "/#create_new#"},
-          {"name": "pool__mask", "value": "255.255.255.255"},
-          {"name": "pool__persist", "value": "/#do_not_use#"},
-          {"name": "monitor__monitor", "value": "/#create_new#"},
-          {"name": "monitor__uri", "value": "/"},
-          {"name": "monitor__frequency", "value": "30"},
-          {"name": "monitor__response", "value": "none"},
-          {"name": "ssl_encryption_questions__advanced", "value": "yes"},
-          {"name": "net__vlan_mode", "value": "all"},
-          {"name": "net__snat_type", "value": "automap"},
-          {"name": "client__tcp_wan_opt", "value": "/#create_new#"},
-          {"name": "client__standard_caching_with_wa", "value": "/#create_new#"},
-          {"name": "client__standard_caching_without_wa", "value": "/#do_not_use#"},
-          {"name": "server__tcp_lan_opt", "value": "/#create_new#"},
-          {"name": "server__oneconnect", "value": "/#create_new#"},
-          {"name": "server__ntlm", "value": "/#do_not_use#"}
-        ]
-      }],
-      "virtualServers": [{
+  "name": "test1",
+  "partition": "test",
+  "iapps": [{
+    "name": "My App Service",
+    "template": "/Common/f5.http",
+    "options": {"description": "This is a test iApp"},
+    "tables": [{
+      "name": "pool__members",
+      "columnNames": ["addr", "port", "connection_limit"],
+      "rows": [{"row": ["1.2.3.4", "30001", "0"]},
+               {"row": ["1.2.3.4", "30002", "0"]},
+               {"row": ["1.2.3.4", "30003", "0"]},
+               {"row": ["1.2.3.4", "30004", "0"]},
+               {"row": ["1.2.3.4", "30005", "0"]}]
+    }
+			  ],        
+    "variables": [
+      {"name": "net__client_mode", "value": "wan"},
+      {"name": "net__server_mode", "value": "lan"},
+      {"name": "pool__addr", "value": "10.10.1.100"},
+      {"name": "pool__port", "value": "80"},
+      {"name": "pool__pool_to_use", "value": "/#create_new#"},
+      {"name": "pool__lb_method", "value": "round-robin"},
+      {"name": "pool__http", "value": "/#create_new#"},
+      {"name": "pool__mask", "value": "255.255.255.255"},
+      {"name": "pool__persist", "value": "/#do_not_use#"},
+      {"name": "monitor__monitor", "value": "/#create_new#"},
+      {"name": "monitor__uri", "value": "/"},
+      {"name": "monitor__frequency", "value": "30"},
+      {"name": "monitor__response", "value": "none"},
+      {"name": "ssl_encryption_questions__advanced", "value": "yes"},
+      {"name": "net__vlan_mode", "value": "all"},
+      {"name": "net__snat_type", "value": "automap"},
+      {"name": "client__tcp_wan_opt", "value": "/#create_new#"},
+      {"name": "client__standard_caching_with_wa", "value": "/#create_new#"},
+      {"name": "client__standard_caching_without_wa", "value": "/#do_not_use#"},
+      {"name": "server__tcp_lan_opt", "value": "/#create_new#"},
+      {"name": "server__oneconnect", "value": "/#create_new#"},
+      {"name": "server__ntlm", "value": "/#do_not_use#"}
+    ]
+  }],
+  "virtualServers": [{
 	"name": "vs1",
 	"destination": "/Test/192.168.0.1:80",
 	"pool": "/Test/pool1",
@@ -60,94 +60,99 @@
 	    {"name": "clientssl", "partition": "Common", "context": "clientside"}
 	  ]
 	}
-      }],
-      "pools": [
-        { "name": "pool1",
-          "members": [
-            {"address": "172.16.0.100", "port": 8080, "routeDomain": {"id": 0}},
-            {"address": "172.16.0.101", "port": 8080, "routeDomain": {"id": 0}}
-          ],
-          "monitors": ["/Test/myhttp"]
-        }
+  }],
+  "pools": [
+    { "name": "pool1",
+      "members": [
+        {"address": "172.16.0.100", "port": 8080, "routeDomain": {"id": 0}},
+        {"address": "172.16.0.101", "port": 8080, "routeDomain": {"id": 0}}
       ],
-      "monitors": [
-        { "name": "myhttp",
-		  "type": "http",
-		  "send": "GET /\r\n",
-		  "recv": "SERVER" },
-        { "name": "myhttps",
-		  "type": "https",
-		  "send": "GET /\r\n",
-		  "recv": "HTTPS-SERVER" },
-        { "name": "my_ping",
-		  "type": "icmp" },
-        { "name": "my_tcp",
-		  "type": "tcp" }
-      ],
-      "l7Policies": [{
-        "name": "wrapper_policy",
-		"strategy": "first",
-		"rules": [
-		  {
-			"conditions": [
-			  {
-				"missing": false,
-				"negate": false,
-				"caseSensitive": false,
-				"value": "www.mysite.com",
-				"operand": "http-uri-host",
-				"condition": "equals"
-			  }
-			],
-			"name": "rule1",
-			"actions": [
-			  {
-				"action": "reject"
-			  }
-			],
-			"order": 0
-		  },
-		  {
-			"conditions": [
-			  {
-				"caseSensitive": false,
-				"missing": false,
-				"value": "www.mysite.com",
-				"negate": true,
-				"operand": "http-uri-host",
-				"condition": "equals"
-			  }
-			],
-			"name": "rule2",
-			"actions": [
-			  {
-				"action": "forward-pool",
-				"target": "/Project/pool2"
-			  }
-			],
-			"order": 1
-		  },
-		  {
-			"conditions": [
-			  {
-				"caseSensitive": false,
-				"missing": false,
-				"httpHeaderName": "X-Foo",
-				"value": "ignore",
-				"negate": true,
-				"operand": "http-header",
-				"condition": "begins-with"
-			  }
-			],
-			"name": "rule3",
-			"actions": [
-			  {
-				"action": "redirect-uri",
-				"target": "www.othersite.com"
-			  }
-			],
-			"order": 2
-		  }
-		]
-      }]
+      "monitors": ["/Test/myhttp"]
+    }
+  ],
+  "monitors": [
+    { "name": "myhttp",
+	  "type": "http",
+	  "send": "GET /\r\n",
+	  "recv": "SERVER" },
+    { "name": "myhttps",
+	  "type": "https",
+	  "send": "GET /\r\n",
+	  "recv": "HTTPS-SERVER" },
+    { "name": "my_ping",
+	  "type": "icmp" },
+    { "name": "my_tcp",
+	  "type": "tcp" }
+  ],
+  "l7Policies": [{
+    "name": "wrapper_policy",
+	"strategy": "/Common/first-match",
+	"rules": {
+	  "items": [
+		{
+		  "conditions": [
+			{
+			  "httpHost": true,
+			  "host": true,
+			  "equals": true,
+			  "values": ["http://www.mysite.com"]
+			},
+			{
+			  "httpUri": true,
+			  "pathSegment": true,
+			  "equals": true,
+			  "values": ["articles"]
+			}
+		  ],
+		  "name": "rule1",
+		  "actions": [
+			{
+			  "request": true,
+			  "forward": true,
+			  "reset": true
+			}
+		  ]
+		},
+		{
+		  "conditions": [
+			{
+			  "httpUri": true,
+			  "path": true,
+			  "not": true,
+			  "equals": true,
+			  "values": ["www.mysite.com"]
+			}
+		  ],
+		  "name": "rule2",
+		  "actions": [
+			{
+			  "forward": true,
+			  "request": true,
+			  "pool": "/Test/pool1"
+			}
+		  ]
+		},
+		{
+		  "conditions": [
+			{
+			  "httpHeader": true,
+			  "caseSensitive": true,
+			  "httpHeaderName": "X-Foo",
+			  "not": true,
+			  "beginsWith": true,
+			  "values": ["ignore"]
+			}
+		  ],
+		  "name": "rule3",
+		  "actions": [
+			{
+			  "request": true,
+			  "redirect": true,
+			  "httpReply": true,
+			  "location": "www.othersite.com"
+			}
+		  ]
+		}
+	  ]}
+  }]
 }


### PR DESCRIPTION
Problem:
Content switching is a requirement for OpenStack and Velcro projects.

Analysis:
Adding the implementation of L7 policies for CCCL. This will support
pool forwarding, reject, and url redirect actions.

Tests:
f5_cccl/resource/ltm/policy/test_policy.py
f5_cccl/resource/ltm/policy/test_rule.py
f5_cccl/resource/ltm/policy/test_action.py
f5_cccl/resource/ltm/policy/test_condition.py