### PR TITLE
Pin module versions in setup_requirements.txt

### DIFF
--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -1,9 +1,9 @@
 # F5-CCCL Install Requirements
 f5-sdk==2.2.2
 ipaddress==1.0.17
-netaddr
+netaddr==0.7.19
 PyJWT==1.4.0
 PyYAML==3.12
 requests==2.9.1
-simplejson
+simplejson==3.10.0
 jsonschema


### PR DESCRIPTION
Problem:
The netaddr and simplejson modules should be pinned to specific
versions.

Solution:
Pinned these 2 modules to the specific versions they were at before the
weekend, when simplejson was updated (and we haven't tested).

Fixes #105