### PR TITLE
Integrating Policy with the service manager, config reader and bigip …

### DIFF
--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -20,6 +20,7 @@ from f5_cccl.resource.ltm.monitor.http_monitor import IcrHTTPMonitor
 from f5_cccl.resource.ltm.monitor.https_monitor import IcrHTTPSMonitor
 from f5_cccl.resource.ltm.monitor.icmp_monitor import IcrICMPMonitor
 from f5_cccl.resource.ltm.monitor.tcp_monitor import IcrTCPMonitor
+from f5_cccl.resource.ltm.policy import IcrPolicy
 from f5_cccl.resource.ltm.pool import IcrPool
 from f5_cccl.resource.ltm.virtual import IcrVirtualServer
 from f5_cccl.resource.ltm.node import Node
@@ -124,7 +125,8 @@ class CommonBigIP(ManagementRoot):
         nodes = self.tm.ltm.nodes.get_collection(
             requests_params={"params": query})
 
-        #  Retrieve the list of pools in managed partition
+        #  Retrieve the list of virtuals, pools, and policies in the
+        #  managed partition getting all subCollections.
         query = "{}&expandSubcollections=true".format(partition_filter)
         virtuals = self.tm.ltm.virtuals.get_collection(
             requests_params={"params": query})
@@ -132,10 +134,10 @@ class CommonBigIP(ManagementRoot):
         pools = self.tm.ltm.pools.get_collection(
             requests_params={"params": query})
 
-        #  Retrieve the list of policies in the managed partition
-        # FIXME: Refresh policies
-        # policies = self.tm.ltm.policys.get_collection(
-        #    requests_params={"params": query})
+        policies = self.tm.ltm.policys.get_collection(
+            requests_params={"params": query})
+
+        #  Refresh the virtuals cache.
         self._virtuals = {
             v.name: IcrVirtualServer(**v.raw) for v in virtuals
             if self._manageable_resource(v)
@@ -150,6 +152,12 @@ class CommonBigIP(ManagementRoot):
         #  Refresh the all-pool cache
         self._all_pools = {
             p.name: IcrPool(**p.raw) for p in pools
+        }
+
+        #  Refresh the policy cache
+        self._policies = {
+            p.name: IcrPolicy(**p.raw) for p in policies
+            if self._manageable_resource(p)
         }
 
         #  Refresh the iapp cache

--- a/f5_cccl/resource/ltm/policy/policy.py
+++ b/f5_cccl/resource/ltm/policy/policy.py
@@ -148,8 +148,10 @@ class IcrPolicy(Policy):
         policy = dict()
         for key in Policy.properties:
             if key == 'rules':
-                policy['rules'] = self._flatten_rules(
-                    data['rulesReference']['items'])
+                rulesReference = data['rulesReference']
+                if 'items' in rulesReference:
+                    policy['rules'] = self._flatten_rules(
+                        rulesReference['items'])
             elif key == 'name' or key == 'partition':
                 pass
             else:
@@ -158,6 +160,7 @@ class IcrPolicy(Policy):
 
     def _flatten_rules(self, rules_list):
         rules = list()
+
         for rule in sorted(rules_list, key=itemgetter('ordinal')):
             flat_rule = dict()
             for key in Rule.properties:

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -99,29 +99,24 @@
         forward:
           type: "boolean"
           description: "This action will affect forwarding."
-          default: True
         request:
           type: "boolean"
           description: "This policy action is performed on connection requests."
-          default: True
         reset:
           type: "boolean"
           description: "This action will reset a connection."
-          default: False
         pool:
           description: "This action will direct the stream to this pool."
           type: "string"
         redirect:
           type: "boolean"
           description: "This action will redirect the request."
-          default: False
         location:
           type: "string"
           description: "This action will come from the given location."
         httpReply:
           type: "boolean"
           description: "This action will affect a reply to a given HTTP request."
-          default: False
 
       oneOf:
         - required:
@@ -193,19 +188,15 @@
         host:
           description: "Matches a host"
           type: "boolean"
-          default: true
         extension:
           description: "Matches an extension(URI file type)."
           type: "boolean"
-          default: true
         path:
           description: "Matches an extension(URI path)."
           type: "boolean"
-          default: true
         pathSegment:
           description: "Matches an extension(URI path segment)."
           type: "boolean"
-          default: true
         index:
           description: "The specified index is used to match a specific segment."
           type: "integer"
@@ -263,7 +254,6 @@
       required: 
         - "name"
         - "rules"
-      additionalProperties: "false"
 
     healthMonitorType: 
       type: "object"

--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -2,7 +2,7 @@
   "name": "test1",
   "partition": "test",
   "iapps": [{
-    "name": "My App Service",
+    "name": "MyAppService0",
     "template": "/Common/f5.http",
     "options": {"description": "This is a test iApp"},
     "tables": [{
@@ -87,72 +87,72 @@
   "l7Policies": [{
     "name": "wrapper_policy",
 	"strategy": "/Common/first-match",
-	"rules": {
-	  "items": [
-		{
-		  "conditions": [
-			{
-			  "httpHost": true,
-			  "host": true,
-			  "equals": true,
-			  "values": ["http://www.mysite.com"]
-			},
-			{
-			  "httpUri": true,
-			  "pathSegment": true,
-			  "equals": true,
-			  "values": ["articles"]
-			}
-		  ],
-		  "name": "rule1",
-		  "actions": [
-			{
-			  "request": true,
-			  "forward": true,
-			  "reset": true
-			}
-		  ]
-		},
-		{
-		  "conditions": [
-			{
-			  "httpUri": true,
-			  "path": true,
-			  "not": true,
-			  "equals": true,
-			  "values": ["www.mysite.com"]
-			}
-		  ],
-		  "name": "rule2",
-		  "actions": [
-			{
-			  "forward": true,
-			  "request": true,
-			  "pool": "/Test/pool1"
-			}
-		  ]
-		},
-		{
-		  "conditions": [
-			{
-			  "httpHeader": true,
-			  "caseSensitive": true,
-			  "httpHeaderName": "X-Foo",
-			  "not": true,
-			  "beginsWith": true,
-			  "values": ["ignore"]
-			}
-		  ],
-		  "name": "rule3",
-		  "actions": [
-			{
-			  "request": true,
-			  "redirect": true,
-			  "httpReply": true,
-			  "location": "www.othersite.com"
-			}
-		  ]
-		}
-	  ]}
+	"rules": [
+	  {
+		"conditions": [
+		  {
+			"httpHost": true,
+			"host": true,
+			"equals": true,
+			"values": ["http://www.mysite.com"]
+		  },
+		  {
+			"httpUri": true,
+			"pathSegment": true,
+			"equals": true,
+			"index": 2,
+			"values": ["articles"]
+		  }
+		],
+		"name": "rule1",
+		"actions": [
+		  {
+			"request": true,
+			"forward": true,
+			"reset": true
+		  }
+		]
+	  },
+	  {
+		"conditions": [
+		  {
+			"httpUri": true,
+			"path": true,
+			"not": true,
+			"equals": true,
+			"values": ["www.mysite.com"]
+		  }
+		],
+		"name": "rule2",
+		"actions": [
+		  {
+			"forward": true,
+			"request": true,
+			"pool": "/Test/pool1"
+		  }
+		]
+	  },
+	  {
+		"conditions": [
+		  {
+			"httpHeader": true,
+			"caseSensitive": true,
+			"tmName": "X-Foo",
+			"not": true,
+			"startsWith": true,
+			"values": ["ignore"]
+		  }
+		],
+		"name": "rule3",
+		"actions": [
+		  {
+			"request": true,
+			"redirect": true,
+			"httpReply": true,
+			"location": "http://www.othersite.com"
+		  }
+		]
+	  }
+	]
   }]
 }

--- a/f5_cccl/service/config_reader.py
+++ b/f5_cccl/service/config_reader.py
@@ -22,6 +22,7 @@ from f5_cccl.resource.ltm.monitor.http_monitor import ApiHTTPMonitor
 from f5_cccl.resource.ltm.monitor.https_monitor import ApiHTTPSMonitor
 from f5_cccl.resource.ltm.monitor.icmp_monitor import ApiICMPMonitor
 from f5_cccl.resource.ltm.monitor.tcp_monitor import ApiTCPMonitor
+from f5_cccl.resource.ltm.policy import ApiPolicy
 from f5_cccl.resource.ltm.pool import ApiPool
 from f5_cccl.resource.ltm.virtual import ApiVirtualServer
 from f5_cccl.resource.ltm.app_service import ApplicationService
@@ -51,6 +52,12 @@ class ServiceConfigReader(object):
         config_dict['pools'] = {
             p['name']: ApiPool(partition=self._partition, **p)
             for p in pools
+        }
+
+        policies = service_config.get('l7Policies', list())
+        config_dict['l7policies'] = {
+            p['name']: ApiPolicy(partition=self._partition, **p)
+            for p in policies
         }
 
         monitors = service_config.get('monitors', list())

--- a/f5_cccl/service/manager.py
+++ b/f5_cccl/service/manager.py
@@ -167,6 +167,12 @@ class ServiceConfigDeployer(object):
         (create_pools, update_pools, delete_pools) = (
             self._get_resource_tasks(existing, desired))
 
+        # Get the list of policy tasks
+        existing = self._bigip.get_l7policies()
+        desired = desired_config.get('l7policies', dict())
+        (create_policies, update_policies, delete_policies) = (
+            self._get_resource_tasks(existing, desired))
+
         # Get the list of iapp tasks
         existing = self._bigip.get_app_svcs()
         desired = desired_config.get('iapps', dict())
@@ -184,11 +190,11 @@ class ServiceConfigDeployer(object):
             self._get_monitor_tasks(desired_config))
 
         create_tasks = create_nodes + create_monitors + create_pools + \
-            create_virtuals + create_iapps
+            create_policies + create_virtuals + create_iapps
         update_tasks = update_nodes + update_monitors + update_pools + \
-            update_virtuals + update_iapps
-        delete_tasks = delete_iapps + delete_virtuals + delete_pools + \
-            delete_monitors + delete_nodes
+            update_policies + update_virtuals + update_iapps
+        delete_tasks = delete_iapps + delete_virtuals + delete_policies + \
+            delete_pools + delete_monitors + delete_nodes
 
         taskq_len = len(create_tasks) + len(update_tasks) + len(delete_tasks)
 

--- a/f5_cccl/service/test/test_service_manager.py
+++ b/f5_cccl/service/test/test_service_manager.py
@@ -18,7 +18,7 @@ import json
 import pickle
 import pytest
 from f5_cccl.test.conftest import big_ip
-
+import pdb
 from f5_cccl.bigip import CommonBigIP
 from f5_cccl.resource import ltm
 
@@ -43,10 +43,10 @@ def service_manager():
     return service_mgr
 
 
-def xtest_apply_config(service_manager):
+def test_apply_config(service_manager):
     services = {}
 
-    assert service_manager.apply_config(services)
+    assert service_manager.apply_config(services) == 0
 
 
 class TestServiceConfigDeployer:
@@ -72,8 +72,8 @@ class TestServiceConfigDeployer:
 
         deployer = ServiceConfigDeployer(
             self.bigip)
-
-        assert 0 == deployer.deploy(self.desired_config)
+        tasks_remaining = deployer.deploy(self.desired_config)
+        assert 0 == tasks_remaining
 
 
     def test_app_services(self, service_manager):
@@ -85,8 +85,9 @@ class TestServiceConfigDeployer:
         service_manager.apply_config(self.service)
         assert deployer._create_resources.called
         args, kwargs = deployer._create_resources.call_args_list[0]
-        assert 6 == len(args[0])
-        assert args[0][5].name == 'My App Service'
+        print(args)
+        assert 7 == len(args[0])
+        assert args[0][6].name == 'MyAppService0'
 
         # Should update one app service
         self.service['iapps'][0]['name'] = 'MyAppService'

--- a/f5_cccl/test/bigip_data.json
+++ b/f5_cccl/test/bigip_data.json
@@ -812,5 +812,6 @@
             "session": "user-enabled",
             "state": "unchecked"
         }
-    ]
+    ],
+    "policies": []
 }

--- a/f5_cccl/test/conftest.py
+++ b/f5_cccl/test/conftest.py
@@ -82,6 +82,37 @@ class Pool():
         return Pool(name)
 
 
+class Policy():
+    """A mock BIG-IP Policy."""
+
+    def __init__(self, name, **kwargs):
+        """Initialize the object."""
+        self.name = name
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.raw = self.__dict__
+
+    def modify(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def update(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def create(self, partition=None, name=None, **kwargs):
+        """Create the policy object."""
+        pass
+
+    def delete(self):
+        """Delete the policy object."""
+        pass
+
+    def load(self, name=None, partition=None):
+        """Load the policy object."""
+        return Policy(name)
+
+
 class Member():
     """A mock BIG-IP Pool Member."""
 
@@ -235,6 +266,10 @@ class MockService():
     def create(self, name=None, template=None, partition=None, variables=None,
                tables=None, trafficGroup=None, description=None):
         """Create a mock iapp."""
+        pass
+
+    def update(self, **properties):
+        """Update a mock iapp."""
         pass
 
     def delete(self):
@@ -455,6 +490,18 @@ class MockPools():
         pass
 
 
+class MockPolicys():
+    """A mock Ltm policy object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.policy = Policy('test')
+
+    def get_collection(self):
+        """Get collection of policies."""
+        pass
+
+
 class MockNodes():
     """A mock Ltm nodes object."""
 
@@ -476,6 +523,7 @@ class MockLtm():
         self.virtuals = MockVirtuals()
         self.pools = MockPools()
         self.nodes = MockNodes()
+        self.policys = MockPolicys()
 
 
 class MockTm():
@@ -532,6 +580,15 @@ class BigIPTest(bigip.CommonBigIP):
 
         return pools
 
+    def mock_policys_get_collection(self, requests_params=None):
+        """Mock: Return a mocked collection of policies."""
+        policies = []
+        for p in self.bigip_data['policies']:
+            policy = Policy(**p)
+            policies.append(policy)
+
+        return policies
+
     def mock_iapps_get_collection(self, requests_params=None):
         """Mock: Return a mocked collection of app svcs."""
         iapps = []
@@ -576,6 +633,8 @@ def big_ip():
 
     big_ip.tm.ltm.pools.get_collection = \
         Mock(side_effect=big_ip.mock_pools_get_collection)
+    big_ip.tm.ltm.policys.get_collection = \
+        Mock(side_effect=big_ip.mock_policys_get_collection)
     big_ip.tm.ltm.virtuals.get_collection = \
         Mock(side_effect=big_ip.mock_virtuals_get_collection)
     big_ip.tm.ltm.monitor.https.get_collection = \


### PR DESCRIPTION
The policy objects need to be managed and deployed by the CCCL service.  This change adds the
policy to the BigIPCommon class to cache it from the BigIP and adds it to the config reader and service deployer.