### PR TITLE
Add Policies to a Virtual Server

### DIFF
--- a/f5_cccl/resource/ltm/test/test_virtual.py
+++ b/f5_cccl/resource/ltm/test/test_virtual.py
@@ -27,12 +27,11 @@ cfg_test = {
     'destination': '1.2.3.4:80',
     'pool': '/my_partition/pool1',
     'ipProtocol': 'tcp',
-    'profilesReference': {
-        'items': [{'name': "tcp",
-                   'partition': "Common",
-                   'context': "all"}
-                  ]
-    },
+    'profiles': [
+        {'name': "tcp",
+         'partition': "Common",
+         'context': "all"}
+    ],
     "enabled": True,
     "vlansEnabled": True,
     "vlans": ["/Test/vlan-100", "/Common/http-tunnel"],
@@ -58,7 +57,10 @@ def test_create_virtual():
 
     # verify all cfg items
     for k,v in cfg_test.items():
-        assert virtual.data[k] == v
+        if k == "vlans":
+            assert virtual.data[k] == sorted(v)
+        else:
+            assert virtual.data[k] == v
 
 
 def test_hash():
@@ -113,8 +115,7 @@ def test_eq():
     assert virtual != virtual2
 
     # different objects
-    with pytest.raises(ValueError):
-        assert virtual != pool 
+    assert virtual != pool
 
 
 def test_uri_path(bigip):

--- a/f5_cccl/resource/ltm/virtual.py
+++ b/f5_cccl/resource/ltm/virtual.py
@@ -46,24 +46,19 @@ class VirtualServer(Resource):
         """Create a Virtual server instance."""
         super(VirtualServer, self).__init__(name, partition)
 
-        for key, value in self.properties.items():
+        for key, default in self.properties.items():
             if key in ["profiles", "policies"]:
-                prop = properties.get(key, value)
+                prop = properties.get(key, default)
                 self._data[key] = sorted(prop, key=itemgetter('name'))
             elif key == "vlans":
-                self._data['vlans'] = sorted(properties.get('vlans', list()))
+                self._data['vlans'] = sorted(properties.get('vlans', default))
             elif key == "sourceAddressTranslation":
                 self._data['sourceAddressTranslation'] = copy(
-                    properties.get('sourceAddressTranslation', dict()))
+                    properties.get('sourceAddressTranslation', default))
             else:
-                self._data[key] = properties.get(key, value)
-
-        # Ensure the vlansEnabled options, enabled and disabled are mutually
-        # exclusive.
-        if self._data.get('vlansEnabled'):
-            self._data.pop('vlansDisabled', None)
-        elif self._data.get('vlansDisabled'):
-            self._data.pop('vlansEnabled', None)
+                value = properties.get(key, default)
+                if value is not None:
+                    self._data[key] = value
 
     def __eq__(self, other):
         if not isinstance(other, VirtualServer):
@@ -80,7 +75,30 @@ class VirtualServer(Resource):
 
 class ApiVirtualServer(VirtualServer):
     """Parse the CCCL input to create the canonical Virtual Server."""
-    pass
+    def __init__(self, name, partition, **properties):
+        """Handle the mutually exclusive properties."""
+
+        enabled = properties.pop('enabled', True)
+        if not enabled:
+            disabled = True
+            enabled = None
+        else:
+            disabled = None
+
+        vlansEnabled = properties.pop('vlansEnabled', False)
+        if not vlansEnabled:
+            vlansDisabled = True
+            vlansEnabled = None
+        else:
+            vlansDisabled = None
+
+        super(ApiVirtualServer, self).__init__(name,
+                                               partition,
+                                               enabled=enabled,
+                                               disabled=disabled,
+                                               vlansEnabled=vlansEnabled,
+                                               vlansDisabled=vlansDisabled,
+                                               **properties)
 
 
 class IcrVirtualServer(VirtualServer):

--- a/f5_cccl/resource/ltm/virtual.py
+++ b/f5_cccl/resource/ltm/virtual.py
@@ -18,6 +18,9 @@
 
 from __future__ import print_function
 
+from copy import copy
+from operator import itemgetter
+
 from f5_cccl.resource import Resource
 from f5_cccl.resource.ltm.profile import Profile
 
@@ -25,68 +28,54 @@ from f5_cccl.resource.ltm.profile import Profile
 class VirtualServer(Resource):
     """Virtual Server class for managing configuration on BIG-IP."""
 
-    properties = dict(name=None,
-                      partition=None,
-                      description=None,
+    properties = dict(description=None,
                       destination=None,
                       ipProtocol=None,
                       enabled=None,
                       disabled=None,
                       vlansEnabled=None,
                       vlansDisabled=None,
-                      vlans=[],
-                      sourceAddressTranslation=None,
+                      vlans=list(),
+                      sourceAddressTranslation=dict(),
                       connectionLimit=0,
                       pool=None,
-                      profilesReference={})
+                      policies=list(),
+                      profiles=list())
 
     def __init__(self, name, partition, **properties):
         """Create a Virtual server instance."""
         super(VirtualServer, self).__init__(name, partition)
 
         for key, value in self.properties.items():
-            if key == "name" or key == "partition":
-                continue
-            if key == "profilesReference":
-                profiles = properties.get('profilesReference', value)
-                items = profiles.get('items', list())
-                self._data['profilesReference'] = self._create_profiles(items)
-                continue
-            self._data[key] = properties.get(key, value)
+            if key in ["profiles", "policies"]:
+                prop = properties.get(key, value)
+                self._data[key] = sorted(prop, key=itemgetter('name'))
+            elif key == "vlans":
+                self._data['vlans'] = sorted(properties.get('vlans', list()))
+            elif key == "sourceAddressTranslation":
+                self._data['sourceAddressTranslation'] = copy(
+                    properties.get('sourceAddressTranslation', dict()))
+            else:
+                self._data[key] = properties.get(key, value)
 
-        if self._data['vlans']:
-            self._data['vlans'].sort()
+        # Ensure the vlansEnabled options, enabled and disabled are mutually
+        # exclusive.
+        if self._data.get('vlansEnabled'):
+            self._data.pop('vlansDisabled', None)
+        elif self._data.get('vlansDisabled'):
+            self._data.pop('vlansEnabled', None)
 
     def __eq__(self, other):
         if not isinstance(other, VirtualServer):
-            raise ValueError(
-                "Invalid comparison of Virtual object with object "
-                "of type {}".format(type(other)))
+            return False
 
-        for key in self.properties:
-            if self._data[key] != other.data.get(key, None):
-                return False
-
-        return True
+        return super(VirtualServer, self).__eq__(other)
 
     def __hash__(self):  # pylint: disable=useless-super-delegation
         return super(VirtualServer, self).__hash__()
 
     def _uri_path(self, bigip):
         return bigip.tm.ltm.virtuals.virtual
-
-    def _create_profiles(self, profiles):
-        profiles_reference = dict()
-
-        items = [
-            Profile(**profile) for profile in profiles
-        ]
-
-        profiles_reference['items'] = [
-            item.data for item in sorted(items)
-        ]
-
-        return profiles_reference
 
 
 class ApiVirtualServer(VirtualServer):
@@ -96,4 +85,45 @@ class ApiVirtualServer(VirtualServer):
 
 class IcrVirtualServer(VirtualServer):
     """Parse the iControl REST input to create the canonical Virtual Server."""
-    pass
+    def __init__(self, name, partition, **properties):
+        """Remove some of the properties that are not required."""
+        self._filter_virtual_properties(**properties)
+
+        profiles = self._flatten_profiles(**properties)
+        policies = self._flatten_policies(**properties)
+
+        super(IcrVirtualServer, self).__init__(name,
+                                               partition,
+                                               profiles=profiles,
+                                               policies=policies,
+                                               **properties)
+
+    def _filter_virtual_properties(self, **properties):
+        """Remove any unneeded properties from the ICR response."""
+
+        # Remove the pool reference property in sourceAddressTranslation
+        snat_translation = properties.get('sourceAddressTranslation', dict())
+        snat_translation.pop('poolReference', None)
+
+        # Flatten the profiles reference.
+
+    def _flatten_profiles(self, **properties):
+        profiles = list()
+        profiles_reference = properties.pop('profilesReference', dict())
+
+        items = profiles_reference.get('items', list())
+        for item in items:
+            profiles.append(Profile(**item).data)
+
+        return profiles
+
+    def _flatten_policies(self, **properties):
+        policies = list()
+        policies_reference = properties.pop('policiesReference', dict())
+
+        items = policies_reference.get('items', list())
+        for item in items:
+            policies.append(dict(name=item['name'],
+                                 partition=item['partition']))
+
+        return policies

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -560,18 +560,10 @@
             type: "array"
             $ref: "#/definitions/policyReferenceType"
 
-        # These 2 options are mutually exclusive and should not be specified together.
         enabled:
           type: "boolean"
           description: |
-            "Enables the virtual server, enabled=True. Note that enabled=False is
-            invalid, you must specify disabled=True"
-        disabled:
-          type: "boolean"
-          description: |
-            "Disable the virtual server, disabled=True. Note that disabled=False is
-            invalid, you must specify enabled=True.  This option is mutually
-            exclusive from enabled."
+            "Enables/disables the virtual server."
 
         sourceAddressTranslation: 
           type: "string"
@@ -588,15 +580,8 @@
         # These 2 options are mutually exclusive and should not be specified together.
         vlansEnabled: 
           description: |
-            "Enables the virtual server on the list of VLANS and
+            "Enables/disables the virtual server on the list of VLANS and
             tunnels listed in the list of vlans.  The default is the virtual server is
-            enabled on all VLANS and tunnel, which corresponds to the setting vlansDisabled=True
-            with an emptly vlans list."
-          type: "boolean"
-        vlansDisabled: 
-          description: |
-            "Disables the virtual server on the list of VLANS and
-            tunnels listed in the set of vlans.  The default is the virtual server is
             enabled on all VLANS and tunnel, which corresponds to the setting vlansDisabled=True
             with an emptly vlans list."
           type: "boolean"

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -55,7 +55,7 @@
       required:
         - "type"
 
-    profileType:
+    profileReferenceType:
       description: "Defines an LTM profile"
       type: "object"
       properties:
@@ -69,6 +69,18 @@
             - "serverside"
             - "clientside"
             - "all"
+      required:
+        - "name"
+        - "partition"
+
+    policyReferenceType:
+      description: "Defines an LTM profile"
+      type: "object"
+      properties:
+        name:
+          type: "string"
+        partition:
+          type: "string"
       required:
         - "name"
         - "partition"
@@ -534,12 +546,19 @@
             The default is 0."
           default: 0
 
-        profilesReference:
+        profiles:
           description: |
             "References the set of profiles that are associated with virtual server"
           items:
             type: "array"
-            $ref: "#/definitions/profileType"
+            $ref: "#/definitions/profileReferenceType"
+
+        policies:
+          description: |
+            "References the set of policies that are associated with virtual server"
+          items:
+            type: "array"
+            $ref: "#/definitions/policyReferenceType"
 
         # These 2 options are mutually exclusive and should not be specified together.
         enabled:

--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -52,14 +52,15 @@
 	  "type": "snat",
 	  "pool": "/Test/snatpool1"
 	},
-	"profilesReference": {
-	  "items": [
-	    {"name": "tcp-lan-optimized", "partition": "Common", "context": "serverside"},
-	    {"name": "tcp-wan-optimized", "partition": "Common", "context": "clientside"},
-	    {"name": "http", "partition": "Common", "context": "all"},
-	    {"name": "clientssl", "partition": "Common", "context": "clientside"}
-	  ]
-	}
+	"profiles": [
+	  {"name": "tcp-lan-optimized", "partition": "Common", "context": "serverside"},
+	  {"name": "tcp-wan-optimized", "partition": "Common", "context": "clientside"},
+	  {"name": "http", "partition": "Common", "context": "all"},
+	  {"name": "clientssl", "partition": "Common", "context": "clientside"}
+	],
+	"policies": [
+	  {"name": "wrapper_policy", "partition": "Test"}
+	]
   }],
   "pools": [
     { "name": "pool1",

--- a/f5_cccl/service/config_reader.py
+++ b/f5_cccl/service/config_reader.py
@@ -85,8 +85,6 @@ class ServiceConfigReader(object):
                         partition=self._partition,
                         **monitor)})
 
-        config_dict['policies'] = {}
-
         iapps = service_config.get('iapps', list())
         config_dict['iapps'] = {
             i['name']: ApplicationService(partition=self._partition, **i)

--- a/f5_cccl/service/test/test_config_reader.py
+++ b/f5_cccl/service/test/test_config_reader.py
@@ -55,5 +55,5 @@ class TestServiceConfigReader:
         assert len(config.get('https_monitors')) == 1
         assert len(config.get('icmp_monitors')) == 1
         assert len(config.get('tcp_monitors')) == 1
-        assert not len(config.get('policies'))
+        assert len(config.get('l7policies')) == 1
         assert len(config.get('iapps')) == 1


### PR DESCRIPTION
This commit flattens the structure of policies and profiles within a Virtual.

Adds support for policies in a VirtualServer.

Fixes SNAT translation initialization in Virtual