### PR TITLE
Allow unattached pools with no related service

### DIFF
--- a/f5_cccl/_f5.py
+++ b/f5_cccl/_f5.py
@@ -285,11 +285,17 @@ class CloudBigIP(BigIP):
                     # multiple pools per virtual need index stripped
                     vname = pool['name'].rsplit('_', 1)[0]
                     if pool['partition'] == partition:
-                        if (pool['name'] in svcs
-                                and 'iapp' not in svcs[pool['name']]):
+                        svc = None
+                        if pool['name'] in svcs:
+                            svc = svcs[pool['name']]
+                        elif vname in svcs:
+                            svc = svcs[vname]
+
+                        if None is svc:
                             cloud_pool_list.append(pool['name'])
-                        elif vname in svcs and 'iapp' not in svcs[vname]:
-                            cloud_pool_list.append(pool['name'])
+                        else:
+                            if 'iapp' not in svc:
+                                cloud_pool_list.append(pool['name'])
 
             cloud_iapp_list = []
             if self._manage_iapp:


### PR DESCRIPTION
Problem: Cloud foundry requires unattached pools which are connected to
a routing virtual server only through policy rules. Kubernetes needs to
support iApps and shouldn't create two pools if a pool is configured to
match the virtual server, but the virtual server is iApp configured. The
restriction is too strong in regards to iApps and prevents cloud foundry
unattached pools from being created.

Solution: Add another condition that allows for unattached pools. If the
pool follows k8s naming conventions it can be found in the f5_services
structure. If the VS found there is configured with an iApp do not add
the pool to the config. If the pool is an unattached orphan and not
found in the f5_services it is ok to configure and won't be a duplicate.

Unit tests and manual tests in CF environment.