### PR TITLE
Fixes #116: Create VirtualAddress resource

### DIFF
--- a/f5_cccl/resource/ltm/test/test_virtual_address.py
+++ b/f5_cccl/resource/ltm/test/test_virtual_address.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from copy import deepcopy
+from mock import Mock
+import pytest
+
+from f5_cccl.resource.ltm.virtual_address import VirtualAddress
+
+va_cfg = {
+    "name": "192.168.100.100",
+    "partition": "Test",
+    "address": "192.168.100.100",
+    "autoDelete": "true",
+    "enabled": "yes",
+    "description": "Test virutal address resource",
+    "trafficGroup": "/Common/traffic-group-local-only"
+}
+
+@pytest.fixture
+def bigip():
+    bigip = Mock()
+    return bigip
+
+
+def test_create_virtual_address():
+    va = VirtualAddress(**va_cfg)
+
+    assert va
+
+    assert va.name == "192.168.100.100"
+    assert va.partition == "Test"
+
+    data = va.data
+    assert data['address'] == "192.168.100.100"
+    assert data['autoDelete'] == "true"
+    assert data['enabled'] == "yes"
+    assert data['description'] == "Test virutal address resource"
+    assert data['trafficGroup'] ==  "/Common/traffic-group-local-only"
+
+
+def test_create_virtual_address_defaults():
+    va = VirtualAddress(name="test_va", partition="Test")
+
+    assert va
+
+    assert va.name == "test_va"
+    assert va.partition == "Test"
+
+    data = va.data
+    assert not data['address']
+    assert data['autoDelete'] == "false"
+    assert not data['enabled']
+    assert not data['description']
+    assert data['trafficGroup'] ==  "/Common/traffic-group-1"
+
+
+def test_equals_virtual_address():
+    va1 = VirtualAddress(**va_cfg)
+    va2 = VirtualAddress(**va_cfg)
+    va3 = deepcopy(va1)
+
+    assert id(va1) != id(va2)
+    assert va1 == va2
+
+    assert id(va1) != id(va3)
+    assert va1 == va3
+
+    va3._data['address'] = "192.168.200.100"
+    assert va1 != va3
+
+    assert va1 != va_cfg
+
+
+def test_get_uri_path(bigip):
+    va = VirtualAddress(**va_cfg)
+
+    assert (va._uri_path(bigip) ==
+            bigip.tm.ltm.virtual_address_s.virtual_address)

--- a/f5_cccl/resource/ltm/virtual_address.py
+++ b/f5_cccl/resource/ltm/virtual_address.py
@@ -1,0 +1,55 @@
+"""Provides a class for managing BIG-IP Virtual Address resources."""
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5_cccl.resource import Resource
+
+
+class VirtualAddress(Resource):
+    """VirtualAddress class for managing configuration on BIG-IP."""
+
+    properties = dict(address=None,
+                      autoDelete="false",
+                      enabled=None,
+                      description=None,
+                      trafficGroup="/Common/traffic-group-1")
+
+    def __init__(self, name, partition, **properties):
+        """Create a VirtualAddress instance."""
+        super(VirtualAddress, self).__init__(name, partition)
+
+        for key, value in self.properties.items():
+            self._data[key] = properties.get(key, value)
+
+    def __eq__(self, other):
+        if not isinstance(other, VirtualAddress):
+            return False
+
+        return super(VirtualAddress, self).__eq__(other)
+
+    def _uri_path(self, bigip):
+        return bigip.tm.ltm.virtual_address_s.virtual_address
+
+
+class IcrVirtualAddress(VirtualAddress):
+    """Filter the iControl REST input to create the canonical representation"""
+    pass
+
+
+class ApiVirtualAddress(VirtualAddress):
+    """Filter the CCCL API input to create the canonical representation"""
+    pass

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -27,6 +27,38 @@
       minimum: 0
       maximum: 65535
 
+    virtualAddressType:
+      definition: "Defines the BigIP virtual address resource."
+      type: "object"
+      properties:
+        name:
+          type: "string"
+        address:
+          description: "This is the VIP"
+          type: "string"
+        enabled:
+          type: "string"
+          description: |
+            "Specifies whether a virtual server IP address is enabled. The default value is yes."
+          enum:
+            - "yes"
+            - "no"
+        autoDelete:
+          type: "string"
+          description: |
+            "Indicates if the virtual address will be automatically deleted on deletion
+            of the last associated virtual server"
+          enum:
+            - "true"
+            - "false"
+        description:
+          type: "string"
+        trafficGroup:
+          description: |
+            "Specifies the traffic group of the virtual address.  The default traffic
+            group is inherited from the containing folder"
+          type: "string"
+
     routeDomainType: 
       type: "object"
       description: "Defines the route domain name and id pair"
@@ -520,7 +552,7 @@
             "Specifies destination IP address information to which 
             the virtual server sends traffic.  This can be an IP address 
             or a previously created virtual-address.  This is of the
-            form /<partition><ip_address>%<route_domain>:<service_port>"
+            form /<partition>/<ip_address>%<route_domain>:<service_port>"
           type: "string"
 
         pool: 
@@ -601,7 +633,11 @@
         - "destination"
         - "name"
 
-  properties: 
+  properties:
+    virtualAddresses:
+      items:
+        $ref: "#/definitions/virtualAddressType"
+      type: "array"
     virtualServers:
       items:
         $ref: "#/definitions/virtualServerType"

--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -1,6 +1,6 @@
 {
   "name": "test1",
-  "partition": "test",
+
   "iapps": [{
     "name": "MyAppService0",
     "template": "/Common/f5.http",
@@ -40,9 +40,23 @@
       {"name": "server__ntlm", "value": "/#do_not_use#"}
     ]
   }],
+  "virtualAddresses": [
+	{
+	  "name": "192.168.0.1%2",
+	  "autoDelete": "false",
+	  "enabled": "yes",
+	  "address": "192.168.0.1"
+	},
+	{
+	  "name": "MyVaddr",
+	  "autoDelete": "false",
+	  "enabled": "no",
+	  "address": "192.168.0.2"
+	}
+  ],
   "virtualServers": [{
 	"name": "vs1",
-	"destination": "/Test/192.168.0.1:80",
+	"destination": "/Test/MyVaddr:80",
 	"pool": "/Test/pool1",
 	"sourceAddress": "0.0.0.0/0",
 	"enabled": true,

--- a/f5_cccl/service/config_reader.py
+++ b/f5_cccl/service/config_reader.py
@@ -18,6 +18,7 @@
 
 from __future__ import print_function
 
+
 from f5_cccl.resource.ltm.monitor.http_monitor import ApiHTTPMonitor
 from f5_cccl.resource.ltm.monitor.https_monitor import ApiHTTPSMonitor
 from f5_cccl.resource.ltm.monitor.icmp_monitor import ApiICMPMonitor
@@ -25,11 +26,13 @@ from f5_cccl.resource.ltm.monitor.tcp_monitor import ApiTCPMonitor
 from f5_cccl.resource.ltm.policy import ApiPolicy
 from f5_cccl.resource.ltm.pool import ApiPool
 from f5_cccl.resource.ltm.virtual import ApiVirtualServer
+from f5_cccl.resource.ltm.virtual_address import ApiVirtualAddress
 from f5_cccl.resource.ltm.app_service import ApplicationService
 
 
 class ServiceConfigReader(object):
     """Class that loads a service defined by cccl-api-schema."""
+
     def __init__(self, partition):
         """Initializer."""
         self._partition = partition
@@ -46,6 +49,13 @@ class ServiceConfigReader(object):
         config_dict['virtuals'] = {
             v['name']: ApiVirtualServer(partition=self._partition, **v)
             for v in virtuals
+        }
+
+        # Get the list of explicitly defined virtual addresses.
+        virtual_addresses = service_config.get('virtualAddresses', list())
+        config_dict['virtual_addresses'] = {
+            va['name']: ApiVirtualAddress(partition=self._partition, **va)
+            for va in virtual_addresses
         }
 
         pools = service_config.get('pools', list())

--- a/f5_cccl/service/test/test_service_manager.py
+++ b/f5_cccl/service/test/test_service_manager.py
@@ -84,8 +84,11 @@ class TestServiceConfigDeployer:
         service_manager.apply_config(self.service)
         assert deployer._create_resources.called
         args, kwargs = deployer._create_resources.call_args_list[0]
-        assert 7 == len(args[0])
-        assert args[0][6].name == 'MyAppService0'
+
+        # The quantity of resources defined in service.json
+        resources_to_create = 9
+        assert resources_to_create == len(args[0])
+        assert args[0][8].name == 'MyAppService0'
 
         # Should update one app service
         self.service['iapps'][0]['name'] = 'MyAppService'

--- a/f5_cccl/test/bigip_data.json
+++ b/f5_cccl/test/bigip_data.json
@@ -813,5 +813,6 @@
             "state": "unchecked"
         }
     ],
-    "policies": []
+    "policies": [],
+    "virtual_addresses": []
 }

--- a/f5_cccl/test/conftest.py
+++ b/f5_cccl/test/conftest.py
@@ -113,6 +113,37 @@ class Policy():
         return Policy(name)
 
 
+class VirtualAddress():
+    """A mock BIG-IP VirtualAddress."""
+
+    def __init__(self, name, **kwargs):
+        """Initialize the object."""
+        self.name = name
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.raw = self.__dict__
+
+    def modify(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def update(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def create(self, partition=None, name=None, **kwargs):
+        """Create the virtual address object."""
+        pass
+
+    def delete(self):
+        """Delete the virtual address object."""
+        pass
+
+    def load(self, name=None, partition=None):
+        """Load the virtual address object."""
+        return VirtualAddress(name)
+
+
 class Member():
     """A mock BIG-IP Pool Member."""
 
@@ -478,6 +509,18 @@ class MockVirtuals():
         pass
 
 
+class MockVirtualAddresses():
+    """A mock Ltm virtual address object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.virtual_address = VirtualAddress('test')
+
+    def get_collection(self):
+        """Get collection of virtual addresses."""
+        return []
+
+
 class MockPools():
     """A mock Ltm pools object."""
 
@@ -524,7 +567,7 @@ class MockLtm():
         self.pools = MockPools()
         self.nodes = MockNodes()
         self.policys = MockPolicys()
-
+        self.virtual_address_s = MockVirtualAddresses()
 
 class MockTm():
     def __init__(self):
@@ -611,6 +654,15 @@ class BigIPTest(bigip.CommonBigIP):
 
         return nodes
 
+    def mock_vas_get_collection(self, requests_params=None):
+        """Mock: Return a mocked collection of virtual addresses."""
+        vas = []
+        for va in self.bigip_data['virtual_addresses']:
+            virtual_address = MockVirtualAddress(**va)
+            vas.append(virtual_address)
+
+        return vas
+
     def read_test_data(self, bigip_state):
         """Read test data for the Big-IP state."""
         # Read the BIG-IP state
@@ -649,5 +701,7 @@ def big_ip():
         Mock(side_effect=big_ip.mock_iapps_get_collection)
     big_ip.tm.ltm.nodes.get_collection = \
         Mock(side_effect=big_ip.mock_nodes_get_collection)
+    big_ip.tm.ltm.virtual_address_s.get_collection = \
+        Mock(side_effect=big_ip.mock_vas_get_collection)
 
     return big_ip

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ passenv = COVERALLS_REPO_TOKEN
 deps =
     -rrequirements.test.txt
 
+# To get the lines that were not executed in unit testing add --cov-report term-missing
+#
 commands =
     # Misc tests
     unit: py.test ./f5_cccl --cov=f5_cccl/ {posargs}


### PR DESCRIPTION
Problem:
In order to manage virtual addresses we need to add a proper type.

Analysis:
Created VirtualAddress class and added management to the bigip cache,
config reader and service deployment classes.  Like nodes, virtual addresses
are cleaned up as part of a post processing step to ensure that those that
were auto-deployed and no longer referenced are removed.

In order to determine which virtual addresses are unreferenced.  The
Virtual class was extended to include a method that would parse the
'destination' field to get the name of the virtual address.

Unit testing was added for all new functionality.

Tests:
f5_cccl/resource/ltm/test/test_virtual.py
f5_cccl/resource/ltm/test/test_virtual_address.py