### PR TITLE
Fixes #124: Virtual destination regex doesn't match all valid partiti…

### DIFF
--- a/f5_cccl/resource/ltm/test/test_virtual.py
+++ b/f5_cccl/resource/ltm/test/test_virtual.py
@@ -187,6 +187,30 @@ def test_ipv4_destination():
     assert destination[2] == "my_virtual_addr%2"
     assert destination[3] == "80"
 
+    cfg = copy(cfg_test)
+    cfg['destination'] = "/Test-1/my_virtual_addr%2:80"
+    virtual = VirtualServer(
+        **cfg
+    )
+
+    destination = virtual.destination
+    assert destination[0] == "/Test-1/my_virtual_addr%2:80"
+    assert destination[1] == "Test-1"
+    assert destination[2] == "my_virtual_addr%2"
+    assert destination[3] == "80"
+
+    cfg = copy(cfg_test)
+    cfg['destination'] = "/Test.1/my_virtual_addr%2:80"
+    virtual = VirtualServer(
+        **cfg
+    )
+
+    destination = virtual.destination
+    assert destination[0] == "/Test.1/my_virtual_addr%2:80"
+    assert destination[1] == "Test.1"
+    assert destination[2] == "my_virtual_addr%2"
+    assert destination[3] == "80"
+
 
 def test_ipv6_destination():
     cfg = copy(cfg_test)

--- a/f5_cccl/resource/ltm/virtual.py
+++ b/f5_cccl/resource/ltm/virtual.py
@@ -34,9 +34,13 @@ class VirtualServer(Resource):
     """Virtual Server class for managing configuration on BIG-IP."""
 
     ipv4_dest_pattern = re.compile(
-        "\\/(\\w+)\\/([a-zA-Z0-9_\\-\\.%]+):(\\d+)$"
+        "\\/([a-zA-Z][\\w_\\.-]+)\\/" +
+        "((?:[a-zA-Z0-9_\\-\\.]+)(?:%\\d+)?):(\\d+)$"
     )
-    ipv6_dest_pattern = re.compile("\\/(\\w+)\\/([a-fA-F0-9:%]+)\\.(\\d+)$")
+    ipv6_dest_pattern = re.compile(
+        "\\/([a-zA-Z][\\w_\\.-]+)\\/" +
+        "((?:[a-fA-F0-9:]+)(?:%\\d+)?)\\.(\\d+)$"
+    )
 
     properties = dict(description=None,
                       destination=None,


### PR DESCRIPTION
…on names

Problem:
The destination pattern regular expressions only match
partition names in A-Za-z0-9_ This excludes valid folder
name characters '.' and '-'.

Analysis:
Modify the regex to include '.' and '-'.  Also check that the partition
name starts with the [A-Za-z] and optionally match the route domain.

Tests:
f5_cccl/resource/ltm/test/test_virtual.py