### PR TITLE
Fixes #83: Validator should decouple schema and config validation.

### DIFF
--- a/f5_cccl/exceptions.py
+++ b/f5_cccl/exceptions.py
@@ -35,21 +35,21 @@ class F5CcclError(Exception):
         return classname
 
 
-class SchemaError(F5CcclError):
+class F5CcclSchemaError(F5CcclError):
     """Error raised when base schema defining API is invalid."""
 
     def __init__(self, msg):
         """Initialize with base schema invalid message."""
-        super(SchemaError, self).__init__(msg)
+        super(F5CcclSchemaError, self).__init__(msg)
         self.msg = 'Schema provided is invalid: ' + msg
 
 
-class ValidationError(F5CcclError):
+class F5CcclValidationError(F5CcclError):
     """Error raised when service config is invalid against the API schema."""
 
     def __init__(self, msg):
         """Initialize with base config does not match schema message."""
-        super(ValidationError, self).__init__(msg)
+        super(F5CcclValidationError, self).__init__(msg)
         self.msg = 'Service congifuration provided does not match schema: ' + \
             msg
 

--- a/f5_cccl/service/test/bad_decode_schema.json
+++ b/f5_cccl/service/test/bad_decode_schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "email": {"type": "string"},
+  },
+  "required": ["email"]
+}

--- a/f5_cccl/service/test/bad_schema.json
+++ b/f5_cccl/service/test/bad_schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "email": {"type": "foo"}
+  },
+  "required": ["email"]
+}

--- a/f5_cccl/service/test/test_schema_validator.py
+++ b/f5_cccl/service/test/test_schema_validator.py
@@ -26,7 +26,7 @@ def validate(validator, services):
         return 'Schema Valid'
     except jsonschema.exceptions.SchemaError:
         return 'Schema Error'
-    except cccl_exc.ValidationError as e:
+    except cccl_exc.F5CcclValidationError as e:
         return 'Validator Error'
 
 


### PR DESCRIPTION
Problem:
The validate() method always performs schema validation on
every call to validate even though it does not change.

The schema should be validated at initialization, and then the
config validated against the schema at each validate() call.

Analysis:
Move the schema validation to the __init__ method.  Also renamed
the exception names for validation to match those of the other
exceptions defined in f5_cccl.

Had to reimplement the tests since they were very tightly
coupled to the implementation.

Tests:
f5_cccl/service/test_validation.py