### PR TITLE
The name and address of the test virtual address are inconsistent

### DIFF
--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -45,7 +45,7 @@
 	  "name": "192.168.0.1%2",
 	  "autoDelete": "false",
 	  "enabled": "yes",
-	  "address": "192.168.0.1"
+	  "address": "192.168.0.1%2"
 	},
 	{
 	  "name": "MyVaddr",


### PR DESCRIPTION
There is a small bug in the configuration which is ok, because we don't test it functionally, but the name and destination of the virtual address are not in the same route domain and they should be.