### PR TITLE
Fixes #128: Modify API to accept a BIG-IP ManagementRoot

### DIFF
--- a/f5_cccl/api.py
+++ b/f5_cccl/api.py
@@ -18,7 +18,7 @@
 
 import logging
 
-from f5_cccl.bigip import CommonBigIP
+from f5_cccl.bigip import BigIPProxy
 from f5_cccl.service.manager import ServiceManager
 
 
@@ -39,30 +39,25 @@ class F5CloudServiceManager(object):
     under its control.
     """
 
-    def __init__(self, hostname, username, password, partition, prefix=None,
-                 port=443, token=None, schema_path=API_SCHEMA):
+    def __init__(self, bigip, partition, prefix=None, schema_path=API_SCHEMA):
         """Initialize an instance of the F5 CCCL service manager.
 
-        :param hostname: BIG-IP hostname or ip address.
-        :param username: Access BIG-IP as user
-        :param password: User password
+        :param bigip: BIG-IP management root.
         :param partition: Name of BIG-IP partition to manage.
-        :param prefix: Optional string to prepend to resource names
-        (default: None).
-        :param port: Port to use for connection (default: 443)
-        :param token: Use for token authentication (default None)
+        :param prefix:  The prefix assigned to resources that should be
+        managed by this CCCL instance.  This is prepended to the
+        resource name (default: None)
+        :param schema_path: User defined schema (default:
+        f5_cccl/schemas/cccl-api-schema.yml)
         """
         LOGGER.debug("F5CloudServiceManager initialize")
-        self._bigip = CommonBigIP(hostname,
-                                  username,
-                                  password,
-                                  partition,
-                                  prefix=prefix,
-                                  port=port,
-                                  token=token)
+        self._bigip_proxy = BigIPProxy(bigip,
+                                       partition,
+                                       prefix=prefix)
 
-        self._service_manager = ServiceManager(self._bigip, partition,
-                                               schema_path, prefix)
+        self._service_manager = ServiceManager(self._bigip_proxy,
+                                               partition,
+                                               schema_path)
 
     def apply_config(self, services):
         """Apply service configurations to the BIG-IP partition.

--- a/f5_cccl/exceptions.py
+++ b/f5_cccl/exceptions.py
@@ -35,21 +35,21 @@ class F5CcclError(Exception):
         return classname
 
 
-class SchemaError(F5CcclError):
+class F5CcclSchemaError(F5CcclError):
     """Error raised when base schema defining API is invalid."""
 
     def __init__(self, msg):
         """Initialize with base schema invalid message."""
-        super(SchemaError, self).__init__(msg)
+        super(F5CcclSchemaError, self).__init__(msg)
         self.msg = 'Schema provided is invalid: ' + msg
 
 
-class ValidationError(F5CcclError):
+class F5CcclValidationError(F5CcclError):
     """Error raised when service config is invalid against the API schema."""
 
     def __init__(self, msg):
         """Initialize with base config does not match schema message."""
-        super(ValidationError, self).__init__(msg)
+        super(F5CcclValidationError, self).__init__(msg)
         self.msg = 'Service congifuration provided does not match schema: ' + \
             msg
 

--- a/f5_cccl/resource/ltm/test/test_app_service.py
+++ b/f5_cccl/resource/ltm/test/test_app_service.py
@@ -18,7 +18,6 @@ from copy import copy, deepcopy
 from f5_cccl.resource.ltm.app_service import ApplicationService
 from f5_cccl.resource.ltm.pool import Pool
 from f5_cccl.resource import Resource
-from f5_cccl.bigip import CommonBigIP
 from mock import Mock
 import pytest
 

--- a/f5_cccl/service/test/bad_decode_schema.json
+++ b/f5_cccl/service/test/bad_decode_schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "email": {"type": "string"},
+  },
+  "required": ["email"]
+}

--- a/f5_cccl/service/test/bad_schema.json
+++ b/f5_cccl/service/test/bad_schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "email": {"type": "foo"}
+  },
+  "required": ["email"]
+}

--- a/f5_cccl/service/test/test_config_reader.py
+++ b/f5_cccl/service/test/test_config_reader.py
@@ -15,13 +15,10 @@
 #
 
 import json
-import pickle
 import pytest
 
 from f5_cccl.api import F5CloudServiceManager
-from f5_cccl.bigip import CommonBigIP
 from f5_cccl.resource import ltm
-
 from f5_cccl.service.manager import ServiceConfigDeployer
 from f5_cccl.service.config_reader import ServiceConfigReader
 

--- a/f5_cccl/service/test/test_schema_validator.py
+++ b/f5_cccl/service/test/test_schema_validator.py
@@ -26,7 +26,7 @@ def validate(validator, services):
         return 'Schema Valid'
     except jsonschema.exceptions.SchemaError:
         return 'Schema Error'
-    except cccl_exc.ValidationError as e:
+    except cccl_exc.F5CcclValidationError as e:
         return 'Validator Error'
 
 

--- a/f5_cccl/service/test/test_service_manager.py
+++ b/f5_cccl/service/test/test_service_manager.py
@@ -17,11 +17,9 @@
 import json
 import pickle
 import pytest
-from f5_cccl.test.conftest import big_ip
-import pdb
-from f5_cccl.bigip import CommonBigIP
-from f5_cccl.resource import ltm
+from f5_cccl.test.conftest import bigip_proxy
 
+from f5_cccl.resource import ltm
 from f5_cccl.service.manager import ServiceConfigDeployer
 from f5_cccl.service.manager import ServiceManager
 from f5_cccl.service.config_reader import ServiceConfigReader
@@ -36,7 +34,7 @@ def service_manager():
     schema = 'f5_cccl/schemas/cccl-api-schema.yml'
 
     service_mgr = ServiceManager(
-        big_ip(),
+        bigip_proxy(),
         partition,
         schema)
 
@@ -52,7 +50,7 @@ def test_apply_config(service_manager):
 class TestServiceConfigDeployer:
 
     def setup(self):
-        self.bigip = big_ip()
+        self.bigip = bigip_proxy()
         self.partition = "test"
 
         svcfile = 'f5_cccl/schemas/tests/service.json'

--- a/f5_cccl/test/test_bigip.py
+++ b/f5_cccl/test/test_bigip.py
@@ -19,8 +19,10 @@ from f5_cccl.resource.ltm.node import Node
 from f5_cccl.resource.ltm.app_service import ApplicationService
 
 
-def test_bigip_refresh(big_ip):
+def test_bigip_refresh(bigip_proxy):
     """Test BIG-IP refresh function."""
+    big_ip = bigip_proxy.mgmt_root()
+
     test_pools = []
     for p in big_ip.bigip_data['pools']:
         pool = IcrPool(**p)
@@ -36,58 +38,60 @@ def test_bigip_refresh(big_ip):
         test_nodes.append(Node(**n))
 
     # refresh the BIG-IP state
-    big_ip.refresh()
+    bigip_proxy.refresh()
 
     # verify pools and pool members
     assert big_ip.tm.ltm.pools.get_collection.called
-    assert len(big_ip._pools) == 2
+    assert len(bigip_proxy._pools) == 2
 
-    assert len(big_ip._pools) == len(test_pools)
+    assert len(bigip_proxy._pools) == len(test_pools)
     for pool in test_pools:
-        assert big_ip._pools[pool.name] == pool
+        assert bigip_proxy._pools[pool.name] == pool
         # Make a change, pools will not be equal
         pool._data['loadBalancingMode'] = 'Not a valid LB mode'
-        assert big_ip._pools[pool.name] != pool
+        assert bigip_proxy._pools[pool.name] != pool
 
     # verify virtual servers 
     assert big_ip.tm.ltm.virtuals.get_collection.called
-    assert len(big_ip._virtuals) == 2
+    assert len(bigip_proxy._virtuals) == 2
 
-    assert len(big_ip._virtuals) == len(test_virtuals)
+    assert len(bigip_proxy._virtuals) == len(test_virtuals)
     for v in test_virtuals:
-        assert big_ip._virtuals[v.name] == v
+        assert bigip_proxy._virtuals[v.name] == v
         # Make a change, virtuals will not be equal
         v._data['partition'] = 'NoPartition'
-        assert big_ip._virtuals[v.name] != v
+        assert bigip_proxy._virtuals[v.name] != v
 
     # verify application services
     assert big_ip.tm.sys.application.services.get_collection.called
-    assert len(big_ip._iapps) == 2
+    assert len(bigip_proxy._iapps) == 2
 
-    assert len(big_ip._iapps) == len(test_iapps)
+    assert len(bigip_proxy._iapps) == len(test_iapps)
     for i in test_iapps:
-        assert big_ip._iapps[i.name] == i
+        assert bigip_proxy._iapps[i.name] == i
         # Make a change, iapps will not be equal
         i._data['template'] = '/Common/NoTemplate'
-        assert big_ip._iapps[i.name] != i
+        assert bigip_proxy._iapps[i.name] != i
 
     # verify nodes
     assert big_ip.tm.ltm.nodes.get_collection.called
-    assert len(big_ip._nodes) == 4
+    assert len(bigip_proxy._nodes) == 4
 
-    assert len(big_ip._nodes) == len(test_nodes)
+    assert len(bigip_proxy._nodes) == len(test_nodes)
     for n in test_nodes:
-        assert big_ip._nodes[n.name] == n
+        assert bigip_proxy._nodes[n.name] == n
 
 
-def test_bigip_properties(big_ip):
+def test_bigip_properties(bigip_proxy):
     """Test BIG-IP properties function."""
+    big_ip = bigip_proxy
+
     test_pools = []
-    for p in big_ip.bigip_data['pools']:
+    for p in big_ip.mgmt_root().bigip_data['pools']:
         pool = IcrPool(**p)
         test_pools.append(pool)
     test_virtuals = []
-    for v in big_ip.bigip_data['virtuals']:
+    for v in big_ip.mgmt_root().bigip_data['virtuals']:
         test_virtuals.append(VirtualServer(**v))
 
     # refresh the BIG-IP state


### PR DESCRIPTION
Problem:
The initial CCCL API used the BIG-IP credentials to instantiate
a CommonBigIP object which was a sub-class of f5.bigip.ManagmentRoot.

This approach was inflexible in that it requires a session be
established for every managed partition on the BIG-IP.

Analysis:
The API was updated to accept an already instantiated bigip mangement
root.  This change requires modifying CommonBigIP from a sub-class
of ManagementRoot to a client.  The name was changed from CommonBigIP
to BigIPProxy to more accurately reflect its purpose, which is
to serve a proxy/cache for CCCl requests to a BIG-IP.

The change required that the test object be restructured as well.
I modified the TestBigIP object to a mock BigIP.

Tests:
f5_cccl/test/test_bigip.py
f5_cccl/service/test/test_service_manager.py