### PR TITLE
Fixes #133:Service config reader can throw undocumented exceptions

### DIFF
--- a/f5_cccl/exceptions.py
+++ b/f5_cccl/exceptions.py
@@ -84,3 +84,7 @@ class F5CcclApplyConfigError(F5CcclError):
 
 class F5CcclCacheRefreshError(F5CcclError):
     u"""Failed to update the BigIP configuration state."""
+
+
+class F5CcclConfigurationReadError(F5CcclError):
+    u"""Failed to create a Resource from the API configuration."""

--- a/f5_cccl/service/test/test_config_reader.py
+++ b/f5_cccl/service/test/test_config_reader.py
@@ -18,7 +18,9 @@ import json
 import pytest
 
 from f5_cccl.api import F5CloudServiceManager
+from f5_cccl.exceptions import F5CcclConfigurationReadError
 from f5_cccl.resource import ltm
+from f5_cccl.resource.ltm.virtual import ApiVirtualServer
 from f5_cccl.service.manager import ServiceConfigDeployer
 from f5_cccl.service.config_reader import ServiceConfigReader
 
@@ -54,3 +56,10 @@ class TestServiceConfigReader:
         assert len(config.get('tcp_monitors')) == 1
         assert len(config.get('l7policies')) == 1
         assert len(config.get('iapps')) == 1
+
+    def test_create_config_item_exception(self):
+
+        with patch.object(ApiVirtualServer, '__init__', side_effect=ValueError("test exception")):
+            reader = ServiceConfigReader(self.partition)
+            with pytest.raises(F5CcclConfigurationReadError) as e:
+                reader.read_config(self.service)

--- a/f5_cccl/test/test_exceptions.py
+++ b/f5_cccl/test/test_exceptions.py
@@ -98,3 +98,12 @@ def test_raise_f5cccl_resource_delete_error():
             raise exceptions.F5CcclResourceDeleteError()
 
         f()
+
+
+def test_raise_f5cccl_configuration_read_error():
+    """Test raising a F5CcclConfigurationReadError."""
+    with pytest.raises(exceptions.F5CcclConfigurationReadError):
+        def f():
+            raise exceptions.F5CcclConfigurationReadError()
+
+        f()


### PR DESCRIPTION
Problem:
When creating CCCL resources from reading the configuration file,
we don't handle any exceptions. We should not rely on the configuration
file having input that will not produce exceptions when reading. We
need to harden the config_reader to handle or document exceptional
conditions.

Analysis:
Create a new exception for configuration reading errors and wrap
each call to create an API resource object with a call to handle
and reraise exceptions that occur when reading a configuration.

Tests:
service/test/test_config_reader.py::test_create_config_item_exception
test/test_exceptions.py::test_raise_f5cccl_configuration_read_error