### PR TITLE
Nightly regression testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ env:
   global:
     - REPO="f5-cccl"
     - PKG_VERSION=$(python -c "import f5_cccl; print f5_cccl.__version__")
-# services:  # needed for later work to build .deb and .rpm natively
-#   - docker
+    - MARATHON_BIGIP_CTLR_COMMIT_ISH=5624ca109e3c003ae051b211d18ede75d8661e2d
+    - K8S_BIGIP_CTLR_COMMIT_ISH=a37e2d3e0ef17ff3fa9534511ced92ec642ce101
+services:
+   - docker
 before_install:
   - git config --global user.email "OpenStack_TravisCI@f5.com"
   - git config --global user.name "Travis F5 Openstack"
@@ -25,4 +27,18 @@ script:
 # https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions
   - if [ "$COVERALLS_REPO_TOKEN" != "" ]; then tox -e coverage; fi
   - tox -e functional
-before_deploy: PKG_VERSION=$(python -c "import f5; print(f5_cccl.__version__)")
+deploy:
+  # push marathon dev-image for nightly regression tests
+  - provider: script
+    skip_cleanup: true
+    script: ./build-tools/system-test-img.sh F5Networks/marathon-bigip-ctlr $MARATHON_BIGIP_CTLR_COMMIT_ISH ./build-tools/build-runtime-images.sh $DOCKER_NAMESPACE
+    on:
+      python: "3.5"
+      all_branches: true
+  # push k8s dev-image for nightly regression tests
+  - provider: script
+    skip_cleanup: true
+    script: ./build-tools/system-test-img.sh F5Networks/k8s-bigip-ctlr $K8S_BIGIP_CTLR_COMMIT_ISH "make prod" $DOCKER_NAMESPACE
+    on:
+      python: "3.5"
+      all_branches: true

--- a/build-tools/system-test-img.sh
+++ b/build-tools/system-test-img.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# builds docker image with top of tree CCCL using build-tools in repo using CCCL
+# for use in system tests within the repo using CCCL
+# local usage example:
+# `./build-tools/system-test-img.sh F5Networks/k8s-bigip-ctlr 3609340 "make prod" f5networksdevel f5devcentral/f5-cccl.git@83d7a311767ea8ca47e144233c4697fce0a3a2bd`
+
+set -ex
+
+USER_REPO=$1
+SHA=$2
+BUILD_CMD=$3
+DOCKER_NAMESPACE=$4
+EDITABLE_REQ=$5
+
+REPO=$(echo $USER_REPO | cut -d "/" -f 2)
+
+if [ \
+    "$USER_REPO" == "" -o \
+    "$SHA" == "" -o \
+    "$BUILD_CMD" == "" -o \
+    "$DOCKER_NAMESPACE" == "" \
+    ]; then
+    echo "[ERROR:] repo, sha, build command & docker namespace required"
+    false
+fi
+
+# in travis, fail f5devcentral commits that cannot push to docker
+# warn and skip docker if on fork
+
+if [ "$TRAVIS" ]; then
+  if [ "$DOCKER_P" == "" -o "$DOCKER_U" == "" -o $DOCKER_NAMESPACE == "" ]; then
+    echo "[INFO] DOCKER_U, DOCKER_P, or DOCKER_NAMESPACE vars absent from travis-ci."
+    if [ "$TRAVIS_REPO_SLUG" == "f5devcentral/f5-cccl" ]; then
+      echo "[ERROR] Docker push for f5devcentral will fail. Contact repo admin."
+      false
+    else
+      echo "[INFO] Not an 'f5devcentral' commit, docker optional."
+      echo "[INFO] Add DOCKER_U, DOCKER_P, and DOCKER_NAMESPACE to travis-ci to push to DockerHub."
+    fi
+  else
+    docker login -u="$DOCKER_U" -p="$DOCKER_P"
+    EDITABLE_REQ="$TRAVIS_REPO_SLUG.git@$TRAVIS_COMMIT"
+    DOCKER_READY="true"
+  fi
+else
+  if [ "$EDITABLE_REQ" == "" ]; then
+    echo "[ERROR] Specify an editable requirement for pip of the form <user>/f5-cccl.git@<sha>"
+    false
+  fi
+  TRAVIS_COMMIT=$(echo $EDITABLE_REQ | cut -d "@" -f 2)
+  TRAVIS_BUILD_ID=$(date +%Y%m%d-%H%M)
+  TRAVIS_BUILD_NUMBER="local"
+  DOCKER_READY="true"
+fi
+
+if [ "$DOCKER_READY" ]; then
+  git clone https://github.com/$USER_REPO.git
+  cd $REPO
+  git checkout -b cccl-systest $SHA
+  find . -name "*requirements.txt" | xargs sed -i -e 's|f5devcentral/f5-cccl\.git@.*#|'"$EDITABLE_REQ"'#|'
+  export IMG_TAG="${DOCKER_NAMESPACE}/cccl:$REPO-${TRAVIS_COMMIT}"
+  $BUILD_CMD
+  docker tag "$IMG_TAG" "$DOCKER_NAMESPACE/cccl:$REPO"
+  docker tag "$IMG_TAG" "$DOCKER_NAMESPACE/cccl:$REPO-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
+  docker push "$IMG_TAG"
+  docker push "$DOCKER_NAMESPACE/cccl:$REPO"
+  docker push "$DOCKER_NAMESPACE/cccl:$REPO-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
+fi


### PR DESCRIPTION
Problem:
CCCL does not have regression testing against a real BIG-IP.

Analysis:
Since CCCL is designed to be used in multiple other projects (e.g. F5Networks/k8s-bigip-ctlr) those projects system tests are an effecitve way to get nightly regressions quickly and to aid in triage for failures. In projects using CCCL those projects 'pin' to a specific SHA of CCCL and tests top of tree for the project using the fixed version of CCCL.

Solution:
- Add custom deploy sections to `.travis.yml` that checkout dependent repos, modifiy the requirements to point to the top of tree commit for CCCL, then build, tag and push those images to DockerHub to make them available for nightly regression testing.
- Added DockerHub credentials for devel registry in travis.
- removed `before_deploy` section. Reference to package was incorrect, but statement was never evaluated as travis viewed the section as a noop without a corresponding `deploy`. If used in future, correct version would be `PKG_VERSION=$(python -c "import f5_cccl; print(f5_cccl.__version__)")`