### PR TITLE
Add iRules support

### DIFF
--- a/f5_cccl/resource/ltm/irule.py
+++ b/f5_cccl/resource/ltm/irule.py
@@ -1,0 +1,77 @@
+"""Provides a class for managing BIG-IP iRule resources."""
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+
+from f5_cccl.resource import Resource
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class IRule(Resource):
+    """iRule class."""
+    # The property names class attribute defines the names of the
+    # properties that we wish to compare.
+    properties = dict(
+        name=None,
+        partition=None,
+        apiAnonymous=None
+    )
+
+    def __init__(self, name, partition, **data):
+        """Create the iRule"""
+        super(IRule, self).__init__(name, partition)
+
+        self._data['apiAnonymous'] = data.get(
+            'apiAnonymous',
+            self.properties.get('apiAnonymous')
+        )
+
+    def __eq__(self, other):
+        """Check the equality of the two objects.
+
+        Only compare the properties as defined in the
+        properties class dictionany.
+        """
+        if not isinstance(other, IRule):
+            return False
+
+        for key in self.properties:
+            if self._data[key] != other.data.get(key, None):
+                return False
+        return True
+
+    def __hash__(self):  # pylint: disable=useless-super-delegation
+        return super(IRule, self).__hash__()
+
+    def _uri_path(self, bigip):
+        return bigip.tm.ltm.rules.rule
+
+    def __str__(self):
+        return str(self._data)
+
+
+class IcrIRule(IRule):
+    """iRule object created from the iControl REST object"""
+    pass
+
+
+class ApiIRule(IRule):
+    """IRule object created from the API configuration object"""
+    pass

--- a/f5_cccl/resource/ltm/test/test_irule.py
+++ b/f5_cccl/resource/ltm/test/test_irule.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from copy import copy
+from f5_cccl.resource.ltm.irule import IRule
+from mock import Mock
+import pytest
+
+
+ssl_redirect_irule_1 = """
+    when HTTP_REQUEST {
+        HTTP::redirect https://[getfield [HTTP::host] \":\" 1][HTTP::uri]
+    }
+    """
+
+cfg_test = {
+    'name': 'ssl_redirect',
+    'partition': 'my_partition',
+    'apiAnonymous': ssl_redirect_irule_1
+}
+
+class FakeObj: pass
+
+
+@pytest.fixture
+def bigip():
+    bigip = Mock()
+    return bigip
+
+
+def test_create_irule():
+    """Test iRule creation."""
+    irule = IRule(
+        **cfg_test
+    )
+    assert irule
+
+    # verify all cfg items
+    for k,v in cfg_test.items():
+        assert irule.data[k] == v
+
+
+def test_hash():
+    """Test Node Server hash."""
+    irule1 = IRule(
+        **cfg_test
+    )
+    irule2 = IRule(
+        **cfg_test
+    )
+    cfg_changed = copy(cfg_test)
+    cfg_changed['name'] = 'test'
+    irule3 = IRule(
+        **cfg_changed
+    )
+    cfg_changed = copy(cfg_test)
+    cfg_changed['partition'] = 'other'
+    irule4 = IRule(
+        **cfg_changed
+    )
+    assert irule1
+    assert irule2
+    assert irule3
+    assert irule4
+
+    assert hash(irule1) == hash(irule2)
+    assert hash(irule1) != hash(irule3)
+    assert hash(irule1) != hash(irule4)
+
+
+def test_eq():
+    """Test iRule equality."""
+    partition = 'Common'
+    name = 'irule_1'
+
+    irule1 = IRule(
+        **cfg_test
+    )
+    irule2 = IRule(
+        **cfg_test
+    )
+    assert irule1
+    assert irule2
+    assert irule1 == irule2
+
+    # name not equal
+    cfg_changed = copy(cfg_test)
+    cfg_changed['name'] = 'ssl_redirect_2'
+    irule2 = IRule(**cfg_changed)
+    assert irule1 != irule2
+
+    # partition not equal
+    cfg_changed = copy(cfg_test)
+    cfg_changed['partition'] = 'test'
+    irule2 = IRule(**cfg_changed)
+    assert irule1 != irule2
+
+    # the actual rule code not equal
+    cfg_changed = copy(cfg_test)
+    cfg_changed['apiAnonymous'] = None
+    irule2 = IRule(**cfg_changed)
+    assert irule1 != irule2
+
+    # different objects
+    fake = FakeObj
+    assert irule1 != fake 
+
+    # should be equal after assignment
+    irule2 = irule1
+    assert irule1 == irule2
+
+
+def test_uri_path(bigip):
+    """Test iRule URI."""
+    irule = IRule(
+        **cfg_test
+    )
+    assert irule
+
+    assert irule._uri_path(bigip) == bigip.tm.ltm.rules.rule

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -712,6 +712,20 @@
         - "destination"
         - "name"
 
+    iRuleType:
+      description: "Defines a reference to an iRule."
+      type: "object"
+      properties:
+        name:
+          type: "string"
+        partition:
+          type: "string"
+        apiAnonymous:
+          type: "string"
+      required:
+        - "name"
+        - "partition"
+
   properties:
     virtualAddresses:
       items:
@@ -736,4 +750,8 @@
     iapps: 
       items: 
         $ref: "#/definitions/iAppType"
+      type: "array"
+    irules:
+      items:
+        $ref: "#/definitions/iRuleType"
       type: "array"

--- a/f5_cccl/service/config_reader.py
+++ b/f5_cccl/service/config_reader.py
@@ -26,6 +26,7 @@ from f5_cccl.resource.ltm.monitor.http_monitor import ApiHTTPMonitor
 from f5_cccl.resource.ltm.monitor.https_monitor import ApiHTTPSMonitor
 from f5_cccl.resource.ltm.monitor.icmp_monitor import ApiICMPMonitor
 from f5_cccl.resource.ltm.monitor.tcp_monitor import ApiTCPMonitor
+from f5_cccl.resource.ltm.irule import ApiIRule
 from f5_cccl.resource.ltm.policy import ApiPolicy
 from f5_cccl.resource.ltm.pool import ApiPool
 from f5_cccl.resource.ltm.virtual import ApiVirtualServer
@@ -98,6 +99,12 @@ class ServiceConfigReader(object):
         config_dict['pools'] = {
             p['name']: self._create_config_item(ApiPool, p)
             for p in pools
+        }
+
+        irules = service_config.get('iRules', list())
+        config_dict['irules'] = {
+            p['name']: self._create_config_item(ApiIRule, p)
+            for p in irules
         }
 
         policies = service_config.get('l7Policies', list())

--- a/f5_cccl/service/manager.py
+++ b/f5_cccl/service/manager.py
@@ -241,6 +241,13 @@ class ServiceConfigDeployer(object):
         (create_pools, update_pools, delete_pools) = (
             self._get_resource_tasks(existing, desired))
 
+        # Get the list of irule tasks
+        LOGGER.debug("Getting iRule tasks...")
+        existing = self._bigip.get_irules()
+        desired = desired_config.get('irules', dict())
+        (create_irules, update_irules, delete_irules) = (
+            self._get_resource_tasks(existing, desired))
+
         # Get the list of policy tasks
         LOGGER.debug("Getting policy tasks...")
         existing = self._bigip.get_l7policies()
@@ -262,11 +269,13 @@ class ServiceConfigDeployer(object):
 
         LOGGER.debug("Building task lists...")
         create_tasks = create_vaddrs + create_monitors + \
-            create_pools + create_policies + create_virtuals + create_iapps
+            create_pools + create_irules + create_policies + \
+            create_virtuals + create_iapps
         update_tasks = update_vaddrs + update_monitors + \
-            update_pools + update_policies + update_virtuals + update_iapps
+            update_pools + update_irules + update_policies + \
+            update_virtuals + update_iapps
         delete_tasks = delete_iapps + delete_virtuals + delete_policies + \
-            delete_pools + delete_monitors
+            delete_irules + delete_pools + delete_monitors
 
         taskq_len = len(create_tasks) + len(update_tasks) + len(delete_tasks)
 

--- a/f5_cccl/test/bigip_data.json
+++ b/f5_cccl/test/bigip_data.json
@@ -814,5 +814,6 @@
         }
     ],
     "policies": [],
-    "virtual_addresses": []
+    "virtual_addresses": [],
+    "irules": []
 }

--- a/f5_cccl/test/conftest.py
+++ b/f5_cccl/test/conftest.py
@@ -113,6 +113,37 @@ class Policy():
         return Policy(name)
 
 
+class IRule():
+    """A mock BIG-IP iRule."""
+
+    def __init__(self, name, **kwargs):
+        """Initialize the object."""
+        self.name = name
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.raw = self.__dict__
+
+    def modify(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def update(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def create(self, partition=None, name=None, **kwargs):
+        """Create the iRule object."""
+        pass
+
+    def delete(self):
+        """Delete the iRule object."""
+        pass
+
+    def load(self, name=None, partition=None):
+        """Load the iRule object."""
+        return IRule(name)
+
+
 class VirtualAddress():
     """A mock BIG-IP VirtualAddress."""
 
@@ -545,6 +576,18 @@ class MockPolicys():
         pass
 
 
+class MockIRules():
+    """A mock Ltm iRules object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.policy = IRule('test')
+
+    def get_collection(self):
+        """Get collection of iRules."""
+        pass
+
+
 class MockNodes():
     """A mock Ltm nodes object."""
 
@@ -567,6 +610,7 @@ class MockLtm():
         self.pools = MockPools()
         self.nodes = MockNodes()
         self.policys = MockPolicys()
+        self.rules = MockIRules()
         self.virtual_address_s = MockVirtualAddresses()
 
 class MockTm():
@@ -632,6 +676,16 @@ class MockBigIP(ManagementRoot):
 
         return policies
 
+    def mock_irules_get_collection(self, requests_params=None):
+        """Mock: Return a mocked collection of iRules."""
+        irules = []
+        #print 'bigip_data:', self.bigip_data
+        for p in self.bigip_data['irules']:
+            irule = IRule(**p)
+            irules.append(irule)
+
+        return irules
+
     def mock_iapps_get_collection(self, requests_params=None):
         """Mock: Return a mocked collection of app svcs."""
         iapps = []
@@ -682,6 +736,8 @@ def bigip_proxy():
         Mock(side_effect=mgmt_root.mock_pools_get_collection)
     mgmt_root.tm.ltm.policys.get_collection = \
         Mock(side_effect=mgmt_root.mock_policys_get_collection)
+    mgmt_root.tm.ltm.rules.get_collection = \
+        Mock(side_effect=mgmt_root.mock_irules_get_collection)
     mgmt_root.tm.ltm.virtuals.get_collection = \
         Mock(side_effect=mgmt_root.mock_virtuals_get_collection)
     mgmt_root.tm.ltm.monitor.https.get_collection = \

--- a/f5_cccl/testcommon.py
+++ b/f5_cccl/testcommon.py
@@ -379,6 +379,7 @@ class BigIPTest(unittest.TestCase):
     virtuals = {}
     profiles = {}
     policies = {}
+    irules = {}
     pools = {}
     virtuals = {}
     members = {}


### PR DESCRIPTION
Problem:
CCCL currently does not support iRules.

Solution:
- Added the necessary objects and functionality to handle iRules.
- Updated the schema to validate iRules.
- Unit tests

affects-branches: master