### PR TITLE
Add Virtual Server iRule linkage

### DIFF
--- a/f5_cccl/resource/ltm/virtual.py
+++ b/f5_cccl/resource/ltm/virtual.py
@@ -54,7 +54,8 @@ class VirtualServer(Resource):
                       connectionLimit=0,
                       pool=None,
                       policies=list(),
-                      profiles=list())
+                      profiles=list(),
+                      rules=list())
 
     def __init__(self, name, partition, **properties):
         """Create a Virtual server instance."""

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -131,6 +131,10 @@
         - "name"
         - "partition"
 
+    iruleReferenceType:
+      description: "Full path to a LTM iRule."
+      type: "string"
+
     policyReferenceType:
       description: "Defines a reference to LTM policy."
       type: "object"
@@ -664,6 +668,13 @@
           items:
             type: "array"
             $ref: "#/definitions/profileReferenceType"
+
+        rules:
+          description: |
+            "References the set of iRules that are associated with virtual server"
+          items:
+            type: "array"
+            $ref: "#/definitions/iruleReferenceType"
 
         policies:
           description: |

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -669,7 +669,7 @@
             type: "array"
             $ref: "#/definitions/profileReferenceType"
 
-        rules:
+        iRules:
           description: |
             "References the set of iRules that are associated with virtual server"
           items:
@@ -735,7 +735,6 @@
           type: "string"
       required:
         - "name"
-        - "partition"
 
   properties:
     virtualAddresses:
@@ -762,7 +761,7 @@
       items: 
         $ref: "#/definitions/iAppType"
       type: "array"
-    irules:
+    iRules:
       items:
         $ref: "#/definitions/iRuleType"
       type: "array"

--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -72,6 +72,9 @@
 	  {"name": "http", "partition": "Common", "context": "all"},
 	  {"name": "clientssl", "partition": "Common", "context": "clientside"}
 	],
+	"iRules": [
+	  {"name": "https_redirect", "partition": "Test"}
+	],
 	"policies": [
 	  {"name": "wrapper_policy", "partition": "Test"}
 	]
@@ -169,5 +172,11 @@
 		]
 	  }
 	]
-  }]
+  }],
+  "iRules": [
+    {
+      "name": "https_redirect",
+      "apiAnonymous": "when HTTP_REQUEST {HTTP::redirect https://[getfield [HTTP::host] ':' 1][HTTP::uri]}"
+    }
+  ]
 }

--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -73,7 +73,7 @@
 	  {"name": "clientssl", "partition": "Common", "context": "clientside"}
 	],
 	"iRules": [
-	  {"name": "https_redirect", "partition": "Test"}
+	  "/Test/https_redirect"
 	],
 	"policies": [
 	  {"name": "wrapper_policy", "partition": "Test"}

--- a/f5_cccl/service/test/test_service_manager.py
+++ b/f5_cccl/service/test/test_service_manager.py
@@ -104,7 +104,7 @@ class TestServiceConfigDeployer:
 
         assert deployer._delete_resources.called
         args, kwargs = deployer._delete_resources.call_args_list[0]
-        assert 6 == len(args[0])
+        assert 7 == len(args[0])
         expected_set = set(['appsvc', 'MyAppService'])
         result_set = set([args[0][0].name, args[0][1].name])
         assert expected_set == result_set

--- a/f5_cccl/test/bigip_data.json
+++ b/f5_cccl/test/bigip_data.json
@@ -34,6 +34,14 @@
             "rateLimitDstMask": 0,
             "rateLimitMode": "object",
             "rateLimitSrcMask": 0,
+            "rules": [
+                "/test/https_redirect"
+            ],
+            "rulesReference": [
+              {
+                "link": "https://localhost/mgmt/tm/ltm/rule/~test~https_redirect?ver=12.1.0"
+              }
+            ],
             "selfLink": "https://localhost/mgmt/tm/ltm/virtual/~Common~virtual1?ver=12.1.0",
             "serviceDownImmediateAction": "none",
             "source": "0.0.0.0/0",
@@ -815,5 +823,15 @@
     ],
     "policies": [],
     "virtual_addresses": [],
-    "irules": []
+    "rules": [
+        {
+            "apiAnonymous": "when HTTP_REQUEST {HTTP::redirect https://[getfield [HTTP::host] ':' 1][HTTP::uri]}",
+            "fullPath": "/test/https_redirect",
+            "generation": 1,
+            "kind": "tm:ltm:rule:rulestate",
+            "name": "https_redirect",
+            "partition": "test",
+            "selfLink": "https://localhost/mgmt/tm/ltm/rule/~test~https_redirect?ver=12.1.0"
+        }
+    ]
 }

--- a/f5_cccl/test/conftest.py
+++ b/f5_cccl/test/conftest.py
@@ -581,7 +581,7 @@ class MockIRules():
 
     def __init__(self):
         """Initialize the object."""
-        self.policy = IRule('test')
+        self.rule = IRule('test')
 
     def get_collection(self):
         """Get collection of iRules."""
@@ -679,8 +679,7 @@ class MockBigIP(ManagementRoot):
     def mock_irules_get_collection(self, requests_params=None):
         """Mock: Return a mocked collection of iRules."""
         irules = []
-        #print 'bigip_data:', self.bigip_data
-        for p in self.bigip_data['irules']:
+        for p in self.bigip_data['rules']:
             irule = IRule(**p)
             irules.append(irule)
 

--- a/f5_cccl/testcommon.py
+++ b/f5_cccl/testcommon.py
@@ -142,6 +142,7 @@ class Virtual(object):
                                                    None)
         self.profiles = kwargs.get('profiles', [])
         self.policies = kwargs.get('policies', [])
+        self.rules = kwargs.get('rules', [])
         self.partition = kwargs.get('partition', None)
 
     def modify(self, **kwargs):
@@ -379,7 +380,7 @@ class BigIPTest(unittest.TestCase):
     virtuals = {}
     profiles = {}
     policies = {}
-    irules = {}
+    rules = {}
     pools = {}
     virtuals = {}
     members = {}


### PR DESCRIPTION
Problem:
Virtual servers can reference iRules but is not supported by CCCL.

Solution:
- Updated the schema for virtualServer to contain an array of iRules.
- Added 'rules' to the VirtualServer object.
- Renamed 'irules' to 'rules' in places where it is required to be
  compatible with the REST API (where iRules are referenced as 'rules')
- Updated unit tests for virtual server to include iRules.
- Fixed some bugs in previous iRule mocks that were uncovered when the
  virtual server unit tests were updated.

affects-branches: master