### PR TITLE
Add support for internal data-groups.

### DIFF
--- a/f5_cccl/resource/ltm/internal_data_group.py
+++ b/f5_cccl/resource/ltm/internal_data_group.py
@@ -1,0 +1,95 @@
+"""Provides a class for managing BIG-IP iRule resources."""
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from copy import deepcopy
+import logging
+
+from f5_cccl.resource import Resource
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_record_key(record):
+    """Allows data groups to be sorted by the 'name' member."""
+    return record.get('name', '')
+
+
+class InternalDataGroup(Resource):
+    """InternalDataGroup class."""
+    # The property names class attribute defines the names of the
+    # properties that we wish to compare.
+    properties = dict(
+        name=None,
+        partition=None,
+        type=None,
+        records=list()
+    )
+
+    def __init__(self, name, partition, **data):
+        """Create the InternalDataGroup"""
+        super(InternalDataGroup, self).__init__(name, partition)
+
+        self._data['type'] = data.get('type', '')
+        records = data.get('records', list())
+        self._data['records'] = sorted(records, key=get_record_key)
+
+    def __eq__(self, other_dg):
+        """Check the equality of the two objects.
+
+        Only compare the properties as defined in the
+        properties class dictionany.
+        """
+        if not isinstance(other_dg, InternalDataGroup):
+            return False
+        for key in self.properties:
+            if self._data[key] != other_dg.data.get(key, None):
+                return False
+        return True
+
+    def __hash__(self):  # pylint: disable=useless-super-delegation
+        return super(InternalDataGroup, self).__hash__()
+
+    def _uri_path(self, bigip):
+        return bigip.tm.ltm.data_group.internals.internal
+
+    def __str__(self):
+        return str(self._data)
+
+    def update(self, bigip, data=None, modify=False):
+        """Override of base class implemntation, required because data-groups
+           are picky about what data can exist in the object when modifying.
+        """
+        tmp_copy = deepcopy(self)
+        tmp_copy.do_update(bigip, data, modify)
+
+    def do_update(self, bigip, data, modify):
+        """Remove 'type' before doing the update."""
+        del self._data['type']
+        super(InternalDataGroup, self).update(
+            bigip, data=data, modify=modify)
+
+
+class IcrInternalDataGroup(InternalDataGroup):
+    """InternalDataGroup object created from the iControl REST object"""
+    pass
+
+
+class ApiInternalDataGroup(InternalDataGroup):
+    """InternalDataGroup object created from the API configuration object"""
+    pass

--- a/f5_cccl/resource/ltm/test/test_internal_data_group.py
+++ b/f5_cccl/resource/ltm/test/test_internal_data_group.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from copy import deepcopy
+from f5_cccl.resource.ltm.internal_data_group import InternalDataGroup
+from mock import Mock
+import pytest
+
+
+cfg_test = {
+    'name': 'test_dg',
+    'partition': 'my_partition',
+    'type': 'string',
+    'records': [
+        {
+            "name": "test_record_name",
+            "data": "test record data"
+        }
+    ]
+}
+
+class FakeObj: pass
+
+
+@pytest.fixture
+def bigip():
+    bigip = Mock()
+    return bigip
+
+
+def test_create_internal_data_group():
+    """Test InternalDataGroup creation."""
+    idg = InternalDataGroup(
+        **cfg_test
+    )
+    assert idg
+
+    # verify all cfg items
+    for k,v in cfg_test.items():
+        assert idg.data[k] == v
+
+
+def test_hash():
+    """Test InternalDataGroup hash."""
+    idg1 = InternalDataGroup(
+        **cfg_test
+    )
+    idg2 = InternalDataGroup(
+        **cfg_test
+    )
+    cfg_changed = deepcopy(cfg_test)
+    cfg_changed['name'] = 'test'
+    idg3 = InternalDataGroup(
+        **cfg_changed
+    )
+    cfg_changed = deepcopy(cfg_test)
+    cfg_changed['partition'] = 'other'
+    idg4 = InternalDataGroup(
+        **cfg_changed
+    )
+
+    assert idg1
+    assert idg2
+    assert idg3
+    assert idg4
+
+    assert hash(idg1) == hash(idg2)
+    assert hash(idg1) != hash(idg3)
+    assert hash(idg1) != hash(idg4)
+
+
+def test_eq():
+    """Test InternalDataGroup equality."""
+    partition = 'Common'
+    name = 'idg_1'
+
+    idg1 = InternalDataGroup(
+        **cfg_test
+    )
+    idg2 = InternalDataGroup(
+        **cfg_test
+    )
+    assert idg1
+    assert idg2
+    assert idg1 == idg2
+
+    # name not equal
+    cfg_changed = deepcopy(cfg_test)
+    cfg_changed['name'] = 'idg_2'
+    idg2 = InternalDataGroup(**cfg_changed)
+    assert idg1 != idg2
+
+    # partition not equal
+    cfg_changed = deepcopy(cfg_test)
+    cfg_changed['partition'] = 'test'
+    idg2 = InternalDataGroup(**cfg_changed)
+    assert idg1 != idg2
+
+    # the records in the group not equal
+    cfg_changed = deepcopy(cfg_test)
+    cfg_changed['records'][0]['data'] = 'changed data'
+    idg2 = InternalDataGroup(**cfg_changed)
+    assert idg1 != idg2
+
+    # different objects
+    fake = FakeObj
+    assert idg1 != fake
+
+    # should be equal after assignment
+    idg2 = idg1
+    assert idg1 == idg2
+
+
+def test_uri_path(bigip):
+    """Test InternalDataGroup URI."""
+    idg = InternalDataGroup(
+        **cfg_test
+    )
+    assert idg
+    assert idg._uri_path(bigip) == bigip.tm.ltm.data_group.internals.internal

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -736,6 +736,41 @@
       required:
         - "name"
 
+    internalDataGroupType:
+      description: "Defines an internal data group."
+      type: "object"
+      properties:
+        name:
+          type: "string"
+        partition:
+          type: "string"
+        type:
+          type: "string"
+          enum:
+            - "string"
+            - "integer"
+            - "ip"
+          default: "string"
+        records:
+          items:
+            type: "array"
+            description: |
+              "List of records associated with this data group."
+            $ref: "#definitions/internalDataGroupRecordType"
+      required:
+        - "name"
+
+    internalDataGroupRecordType:
+      description: "Defines a data group record."
+      type: "object"
+      properties:
+        name:
+          type: "string"
+        data:
+          type: "string"
+      required:
+        - "name"
+
   properties:
     virtualAddresses:
       items:
@@ -764,4 +799,8 @@
     iRules:
       items:
         $ref: "#/definitions/iRuleType"
+      type: "array"
+    internalDataGroups:
+      items:
+        $ref: "#/definitions/internalDataGroupType"
       type: "array"

--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -178,5 +178,17 @@
       "name": "https_redirect",
       "apiAnonymous": "when HTTP_REQUEST {HTTP::redirect https://[getfield [HTTP::host] ':' 1][HTTP::uri]}"
     }
+  ],
+  "internalDataGroups": [
+    {
+      "name": "test-dgs",
+      "type": "string",
+      "records": [
+        {
+          "name": "record-name",
+          "data": "data-value"
+        }
+      ]
+    }
   ]
 }

--- a/f5_cccl/service/config_reader.py
+++ b/f5_cccl/service/config_reader.py
@@ -32,6 +32,7 @@ from f5_cccl.resource.ltm.pool import ApiPool
 from f5_cccl.resource.ltm.virtual import ApiVirtualServer
 from f5_cccl.resource.ltm.virtual_address import ApiVirtualAddress
 from f5_cccl.resource.ltm.app_service import ApplicationService
+from f5_cccl.resource.ltm.internal_data_group import ApiInternalDataGroup
 
 
 LOGGER = logging.getLogger(__name__)
@@ -111,6 +112,12 @@ class ServiceConfigReader(object):
         config_dict['l7policies'] = {
             p['name']: self._create_config_item(ApiPolicy, p)
             for p in policies
+        }
+
+        internal_dgs = service_config.get('internalDataGroups', list())
+        config_dict['internaldatagroups'] = {
+            p['name']: self._create_config_item(ApiInternalDataGroup, p)
+            for p in internal_dgs
         }
 
         monitors = service_config.get('monitors', list())

--- a/f5_cccl/service/manager.py
+++ b/f5_cccl/service/manager.py
@@ -277,13 +277,13 @@ class ServiceConfigDeployer(object):
 
         LOGGER.debug("Building task lists...")
         create_tasks = create_vaddrs + create_monitors + \
-            create_pools + create_irules + create_internal_data_groups + \
+            create_pools + create_internal_data_groups + create_irules + \
             create_policies + create_virtuals + create_iapps
         update_tasks = update_vaddrs + update_monitors + \
-            update_pools + update_irules + update_internal_data_groups + \
+            update_pools + update_internal_data_groups + update_irules + \
             update_policies + update_virtuals + update_iapps
         delete_tasks = delete_iapps + delete_virtuals + delete_policies + \
-            delete_internal_data_groups + delete_irules + delete_pools + \
+            delete_irules + delete_internal_data_groups + delete_pools + \
             delete_monitors
 
         taskq_len = len(create_tasks) + len(update_tasks) + len(delete_tasks)

--- a/f5_cccl/service/manager.py
+++ b/f5_cccl/service/manager.py
@@ -248,6 +248,14 @@ class ServiceConfigDeployer(object):
         (create_irules, update_irules, delete_irules) = (
             self._get_resource_tasks(existing, desired))
 
+        # Get the list of internal data group tasks
+        LOGGER.debug("Getting InternalDataGroup tasks...")
+        existing = self._bigip.get_internal_data_groups()
+        desired = desired_config.get('internaldatagroups', dict())
+        (create_internal_data_groups, update_internal_data_groups,
+         delete_internal_data_groups) = (
+             self._get_resource_tasks(existing, desired))
+
         # Get the list of policy tasks
         LOGGER.debug("Getting policy tasks...")
         existing = self._bigip.get_l7policies()
@@ -269,13 +277,14 @@ class ServiceConfigDeployer(object):
 
         LOGGER.debug("Building task lists...")
         create_tasks = create_vaddrs + create_monitors + \
-            create_pools + create_irules + create_policies + \
-            create_virtuals + create_iapps
+            create_pools + create_irules + create_internal_data_groups + \
+            create_policies + create_virtuals + create_iapps
         update_tasks = update_vaddrs + update_monitors + \
-            update_pools + update_irules + update_policies + \
-            update_virtuals + update_iapps
+            update_pools + update_irules + update_internal_data_groups + \
+            update_policies + update_virtuals + update_iapps
         delete_tasks = delete_iapps + delete_virtuals + delete_policies + \
-            delete_irules + delete_pools + delete_monitors
+            delete_internal_data_groups + delete_irules + delete_pools + \
+            delete_monitors
 
         taskq_len = len(create_tasks) + len(update_tasks) + len(delete_tasks)
 

--- a/f5_cccl/service/test/test_service_manager.py
+++ b/f5_cccl/service/test/test_service_manager.py
@@ -84,9 +84,9 @@ class TestServiceConfigDeployer:
         args, kwargs = deployer._create_resources.call_args_list[0]
 
         # The quantity of resources defined in service.json
-        resources_to_create = 9
+        resources_to_create = 10
         assert resources_to_create == len(args[0])
-        assert args[0][8].name == 'MyAppService0'
+        assert args[0][9].name == 'MyAppService0'
 
         # Should update one app service
         self.service['iapps'][0]['name'] = 'MyAppService'
@@ -104,7 +104,7 @@ class TestServiceConfigDeployer:
 
         assert deployer._delete_resources.called
         args, kwargs = deployer._delete_resources.call_args_list[0]
-        assert 7 == len(args[0])
+        assert 8 == len(args[0])
         expected_set = set(['appsvc', 'MyAppService'])
         result_set = set([args[0][0].name, args[0][1].name])
         assert expected_set == result_set

--- a/f5_cccl/test/bigip_data.json
+++ b/f5_cccl/test/bigip_data.json
@@ -833,5 +833,22 @@
             "partition": "test",
             "selfLink": "https://localhost/mgmt/tm/ltm/rule/~test~https_redirect?ver=12.1.0"
         }
+    ],
+    "internaldatagroups": [
+        {
+            "fullPath": "/test/test-dg",
+            "generation": 1,
+            "kind": "tm:ltm:data-group:internal:internal-state",
+            "name": "test-dg",
+            "partition": "test",
+            "records": [
+                {
+                    "name": "record-name",
+                    "data": "data-value"
+                }
+            ],
+            "selfLink": "https://localhost/mgmt/tm/ltm/data-group/internal/~test~test-dg?ver=12.1.0",
+            "type": "string"
+        }
     ]
 }

--- a/f5_cccl/test/conftest.py
+++ b/f5_cccl/test/conftest.py
@@ -399,6 +399,38 @@ class Iapp():
         pass
 
 
+class InternalDataGroup():
+    """A mock BIG-IP data_group internal."""
+
+    def __init__(self, name, **kwargs):
+        """Initialize the object."""
+        self.name = name
+        #self.partition = partition
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.raw = self.__dict__
+
+    def modify(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def update(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def create(self, partition=None, name=None, **kwargs):
+        """Create the iRule object."""
+        pass
+
+    def delete(self):
+        """Delete the iRule object."""
+        pass
+
+    def load(self, name=None, partition=None):
+        """Load the iRule object."""
+        return InternalDataGroup(name, partition)
+
+
 class MockFolder():
     """A mock BIG-IP folder object."""
 
@@ -600,6 +632,51 @@ class MockNodes():
         pass
 
 
+class MockDataGroupInternals():
+    """A mock Ltm data-group internals object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.internal = MockDataGroupInternal()
+        pass
+
+
+class MockDataGroupInternal():
+    """A mock Ltm data-group internal object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        pass
+
+    def modify(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def update(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def create(self, partition=None, name=None, **kwargs):
+        """Create the object."""
+        pass
+
+    def delete(self):
+        """Delete the object."""
+        pass
+
+    def load(self, name=None, partition=None):
+        """Load the object."""
+        return InternalDataGroup(name)
+
+
+class MockDataGroup():
+    """A mock Ltm data_group object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.internals = MockDataGroupInternals()
+
+
 class MockLtm():
     """A mock BIG-IP ltm object."""
 
@@ -612,6 +689,7 @@ class MockLtm():
         self.policys = MockPolicys()
         self.rules = MockIRules()
         self.virtual_address_s = MockVirtualAddresses()
+        self.data_group = MockDataGroup()
 
 class MockTm():
     def __init__(self):
@@ -716,6 +794,15 @@ class MockBigIP(ManagementRoot):
 
         return vas
 
+    def mock_data_group_internals_get_collection(self, requests_params=None):
+        """Mock: Return a mocked collection of data_group internal."""
+        int_dgs = []
+        for p in self.bigip_data['internaldatagroups']:
+            dg = InternalDataGroup(**p)
+            int_dgs.append(dg)
+
+        return int_dgs
+
     def read_test_data(self, bigip_state):
         """Read test data for the Big-IP state."""
         # Read the BIG-IP state
@@ -753,6 +840,8 @@ def bigip_proxy():
         Mock(side_effect=mgmt_root.mock_nodes_get_collection)
     mgmt_root.tm.ltm.virtual_address_s.get_collection = \
         Mock(side_effect=mgmt_root.mock_vas_get_collection)
+    mgmt_root.tm.ltm.data_group.internals.get_collection = \
+        Mock(side_effect=mgmt_root.mock_data_group_internals_get_collection)
 
     bigip_state='f5_cccl/test/bigip_data.json'
     mgmt_root.read_test_data(bigip_state)

--- a/f5_cccl/testcommon.py
+++ b/f5_cccl/testcommon.py
@@ -360,6 +360,7 @@ class MockLtm(object):
         self.monitor = MockMonitor()
         self.virtuals = MockVirtuals()
         self.pools = MockPools()
+        self.data_group = MockPools()
 
 
 class MockHealthMonitor(object):
@@ -369,6 +370,26 @@ class MockHealthMonitor(object):
         """Initialize the object."""
         self.name = name
         self.partition = partition
+
+
+class MockDataGroupInternals(object):
+    """A mock Ltm data-group internals object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        pass
+
+    def get_collection(self):
+        """Get collection of nodes."""
+        pass
+
+
+class MockDataGroup(object):
+    """A mock Ltm data_group object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.internals = MockDataGroupInternals()
 
 
 class BigIPTest(unittest.TestCase):

--- a/f5_cccl/testcommon.py
+++ b/f5_cccl/testcommon.py
@@ -360,7 +360,7 @@ class MockLtm(object):
         self.monitor = MockMonitor()
         self.virtuals = MockVirtuals()
         self.pools = MockPools()
-        self.data_group = MockPools()
+        self.data_group = MockDataGroupInternals()
 
 
 class MockHealthMonitor(object):


### PR DESCRIPTION
Problem:
CCCL needs support for internal data-groups as they are required by
some iRules.

Solution:
- Updated the schema to understand internal data-groups.
- Added CRUD operations for the new data type.
- Updated existing unit tests to exercise the new data type.
- Added new unit tests for internal data-groups.

affects-branches: master