### PR TITLE
Issue #139: Simplify schema for iApps

### DIFF
--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -25,7 +25,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from f5.sdk_exception import F5SDKError
 
 import f5_cccl.exceptions as cccl_exc
-from f5_cccl.resource.ltm.app_service import ApplicationService
+from f5_cccl.resource.ltm.app_service import IcrApplicationService
 from f5_cccl.resource.ltm.monitor.http_monitor import IcrHTTPMonitor
 from f5_cccl.resource.ltm.monitor.https_monitor import IcrHTTPSMonitor
 from f5_cccl.resource.ltm.monitor.icmp_monitor import IcrICMPMonitor
@@ -296,7 +296,7 @@ class BigIPProxy(object):
 
         #  Refresh the iapp cache
         self._iapps = {
-            i.name: self._create_resource(ApplicationService, i)
+            i.name: self._create_resource(IcrApplicationService, i)
             for i in iapps if i.name.startswith(self._prefix)
         }
 

--- a/f5_cccl/resource/ltm/app_service.py
+++ b/f5_cccl/resource/ltm/app_service.py
@@ -48,13 +48,8 @@ class ApplicationService(Resource):
                 for opt in value:
                     if opt in properties:
                         self._data[opt] = properties.get(opt, value)
-            else:
+            if key == "template":
                 self._data[key] = properties.get(key, value)
-
-                if key == "variables":
-                    # Remove 'encrypted' key and its value from ICR data
-                    for v in self._data[key]:
-                        v.pop('encrypted', None)
 
     def __eq__(self, other):
         if not isinstance(other, ApplicationService):
@@ -96,3 +91,97 @@ class ApplicationService(Resource):
         """
         self._data['executeAction'] = 'definition'
         super(ApplicationService, self).update(bigip, data=data, modify=modify)
+
+
+class IcrApplicationService(ApplicationService):
+    """Parse iControl REST input to create canonical Application Service."""
+    def __init__(self, name, partition, **properties):
+        super(IcrApplicationService, self).__init__(name,
+                                                    partition,
+                                                    **properties)
+        for key, value in self.properties.items():
+            if key == "variables":
+                self._data[key] = properties.get(key, value)
+                # Remove 'encrypted' key and its value from ICR data
+                for v in self._data[key]:
+                    v.pop('encrypted', None)
+            if key == "tables":
+                self._data[key] = properties.get(key, value)
+
+
+class ApiApplicationService(ApplicationService):
+    """Parse the CCCL input to create the canonical Application Service."""
+    def __init__(self, name, partition, **properties):
+        super(ApiApplicationService, self).__init__(name,
+                                                    partition,
+                                                    **properties)
+        members = []
+        if 'poolMemberTable' in properties:
+            members = properties['poolMemberTable'].get("members", [])
+
+        # iapp_def = self._iapp_build_definition(members, properties)
+        self._data["variables"] = self._iapp_build_variables(properties)
+        self._data["tables"] = self._iapp_build_tables(members, properties)
+
+    def _iapp_build_variables(self, config):
+        """Create a list of name-value objects."""
+        variables = []
+        for key, value in config['variables'].items():
+            var = {'name': key, 'value': value}
+            variables.append(var)
+
+        return variables
+
+    def _iapp_build_tables(self, members, config):
+        """Create a dict that defines the tables for an iApp.
+
+        Args:
+            members: list of pool members
+            config: BIG-IP config dict
+        """
+        # The schema says only one of poolMemberTable or tableName is
+        # valid, so if the user set both it should have already been rejected.
+        # But if not, prefer the new poolMemberTable over tableName.
+        tables = []
+        if 'poolMemberTable' in config:
+            tableConfig = config['poolMemberTable']
+
+            # Construct columnNames array from the 'name' prop of each column
+            columnNames = [col['name'] for col in tableConfig['columns']]
+
+            # Construct rows array - one row for each node, interpret the
+            # 'kind' or 'value' from the column spec.
+            rows = []
+            for node in members:
+                row = []
+                for col in tableConfig['columns']:
+                    if 'value' in col:
+                        row.append(col['value'])
+                    elif 'kind' in col:
+                        if col['kind'] == 'IPAddress':
+                            row.append(str(node['address']))
+                        elif col['kind'] == 'Port':
+                            row.append(str(node['port']))
+
+                rows.append({'row': row})
+
+            # Done - add the generated pool member table to the set of tables
+            # we're going to configure.
+            tables.append({
+                'name': tableConfig['name'],
+                'columnNames': columnNames,
+                'rows': rows
+            })
+
+        # Add other tables
+        if 'tables' in config:
+            for key in config['tables']:
+                data = config['tables'][key]
+                table = {'columnNames': data['columns'],
+                         'name': key,
+                         'rows': []}
+                for row in data['rows']:
+                    table['rows'].append({'row': row})
+                tables.append(table)
+
+        return tables

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -565,6 +565,52 @@ definitions:
     - "columns"
     - "rows"
 
+  iAppAddressType:
+    type: "object"
+    properties:
+      name:
+        description: >
+          Specifies the name of the IP address column in the pool-member table
+        type: "string"
+        minLength: 1 
+      kind:
+        type: "string"
+        enum: 
+        - "IPAddress"
+    required:
+    - "name"
+    - "kind"
+
+  iAppPortType:
+    type: "object"
+    properties:
+      name:
+        description: >
+          Specifies the name of the port column in the pool-member table
+        type: "string"
+        minLength: 1
+      kind:
+        type: "string"
+        enum: 
+         - "Port"
+    required:
+    - "name"
+    - "kind"
+
+  iAppValueType:
+    type: "object"
+    properties:
+      name:
+        description: >
+          Specifies the name of a value column in the pool-member table
+        type: "string"
+        minLength: 1
+      value:
+        type: "string"
+    required:
+    - "name"
+    - "value"
+
   iAppType:
     type: "object"
     properties:
@@ -595,23 +641,43 @@ definitions:
           trafficGroup:
             type: "string"
             minLength: 1
+      poolMemberTable:
+        desription: "Specifies the format and content of the pool members"
+        type: "object"
+        properties:
+          name:
+            description: "The pool-member table name"
+            type: "string"
+            minLength: 1
+          columns:
+            description: "Specifies the column names of the table"
+            type: "array"
+            items:
+              oneOf:
+              - $ref: "#/definitions/iAppAddressType"
+              - $ref: "#/definitions/iAppPortType"
+              - $ref: "#/definitions/iAppValueType"
+        required:
+        - "name"
+        - "columns"
+        members:
+          description: "List of pool members"
+          items:
+            type: "array"
+            $ref: "#definitions/poolMemberType"
       tables:
-        description: "Specifies an array of tables, e.g. L7 policies, pool
-                     members"
-        type: "array"
+        description: >
+          Specifies an array of tables, e.g. L7 policies
+        type: "object"
         patternProperties:
           "^[a-zA-Z0-9_-]+$":
             "$ref": "#/definitions/iappTableType"
       variables:
         description: "Application-service specific name-value pairs"
-        type  : "array"
-        items:
-          properties:
-            name:
-              type: "string"
-              minLength: 1
-            value:
-              type: "string"
+        type: "object"
+        patternProperties:
+          "^[a-zA-Z0-9_-]+$":
+            type: "string"
     required:
     - "template"
     - "variables"

--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -5,40 +5,45 @@
     "name": "MyAppService0",
     "template": "/Common/f5.http",
     "options": {"description": "This is a test iApp"},
-    "tables": [{
+    "poolMemberTable": {
       "name": "pool__members",
-      "columnNames": ["addr", "port", "connection_limit"],
-      "rows": [{"row": ["1.2.3.4", "30001", "0"]},
-               {"row": ["1.2.3.4", "30002", "0"]},
-               {"row": ["1.2.3.4", "30003", "0"]},
-               {"row": ["1.2.3.4", "30004", "0"]},
-               {"row": ["1.2.3.4", "30005", "0"]}]
+      "columns": [
+        {"name": "addr", "kind": "IPAddress"},
+        {"name": "port", "kind": "Port"},
+        {"name": "connection_limit", "value": "0"}
+      ],
+      "members": [
+        {"address": "1.2.3.4", "port": 30001},
+        {"address": "1.2.3.4", "port": 30002},
+        {"address": "1.2.3.4", "port": 30003},
+        {"address": "1.2.3.4", "port": 30004},
+        {"address": "1.2.3.4", "port": 30005}
+      ]
+    },
+    "variables": {
+      "net__client_mode": "wan",
+      "net__server_mode": "lan",
+      "pool__addr": "10.10.1.100",
+      "pool__port": "80",
+      "pool__pool_to_use": "/#create_new#",
+      "pool__lb_method": "round-robin",
+      "pool__http": "/#create_new#",
+      "pool__mask": "255.255.255.255",
+      "pool__persist": "/#do_not_use#",
+      "monitor__monitor": "/#create_new#",
+      "monitor__uri": "/",
+      "monitor__frequency": "30",
+      "monitor__response": "none",
+      "ssl_encryption_questions__advanced": "yes",
+      "net__vlan_mode": "all",
+      "net__snat_type": "automap",
+      "client__tcp_wan_opt": "/#create_new#",
+      "client__standard_caching_with_wa": "/#create_new#",
+      "client__standard_caching_without_wa": "/#do_not_use#",
+      "server__tcp_lan_opt": "/#create_new#",
+      "server__oneconnect": "/#create_new#",
+      "server__ntlm": "/#do_not_use#"
     }
-			  ],        
-    "variables": [
-      {"name": "net__client_mode", "value": "wan"},
-      {"name": "net__server_mode", "value": "lan"},
-      {"name": "pool__addr", "value": "10.10.1.100"},
-      {"name": "pool__port", "value": "80"},
-      {"name": "pool__pool_to_use", "value": "/#create_new#"},
-      {"name": "pool__lb_method", "value": "round-robin"},
-      {"name": "pool__http", "value": "/#create_new#"},
-      {"name": "pool__mask", "value": "255.255.255.255"},
-      {"name": "pool__persist", "value": "/#do_not_use#"},
-      {"name": "monitor__monitor", "value": "/#create_new#"},
-      {"name": "monitor__uri", "value": "/"},
-      {"name": "monitor__frequency", "value": "30"},
-      {"name": "monitor__response", "value": "none"},
-      {"name": "ssl_encryption_questions__advanced", "value": "yes"},
-      {"name": "net__vlan_mode", "value": "all"},
-      {"name": "net__snat_type", "value": "automap"},
-      {"name": "client__tcp_wan_opt", "value": "/#create_new#"},
-      {"name": "client__standard_caching_with_wa", "value": "/#create_new#"},
-      {"name": "client__standard_caching_without_wa", "value": "/#do_not_use#"},
-      {"name": "server__tcp_lan_opt", "value": "/#create_new#"},
-      {"name": "server__oneconnect", "value": "/#create_new#"},
-      {"name": "server__ntlm", "value": "/#do_not_use#"}
-    ]
   }],
   "virtualAddresses": [
 	{

--- a/f5_cccl/service/config_reader.py
+++ b/f5_cccl/service/config_reader.py
@@ -31,7 +31,7 @@ from f5_cccl.resource.ltm.policy import ApiPolicy
 from f5_cccl.resource.ltm.pool import ApiPool
 from f5_cccl.resource.ltm.virtual import ApiVirtualServer
 from f5_cccl.resource.ltm.virtual_address import ApiVirtualAddress
-from f5_cccl.resource.ltm.app_service import ApplicationService
+from f5_cccl.resource.ltm.app_service import ApiApplicationService
 from f5_cccl.resource.ltm.internal_data_group import ApiInternalDataGroup
 
 
@@ -143,7 +143,7 @@ class ServiceConfigReader(object):
 
         iapps = service_config.get('iapps', list())
         config_dict['iapps'] = {
-            i['name']: self._create_config_item(ApplicationService, i)
+            i['name']: self._create_config_item(ApiApplicationService, i)
             for i in iapps
         }
 

--- a/f5_cccl/test/test_bigip.py
+++ b/f5_cccl/test/test_bigip.py
@@ -16,7 +16,7 @@
 from f5_cccl.resource.ltm.pool import IcrPool
 from f5_cccl.resource.ltm.virtual import VirtualServer
 from f5_cccl.resource.ltm.node import Node
-from f5_cccl.resource.ltm.app_service import ApplicationService
+from f5_cccl.resource.ltm.app_service import IcrApplicationService
 
 
 def test_bigip_refresh(bigip_proxy):
@@ -32,7 +32,7 @@ def test_bigip_refresh(bigip_proxy):
         test_virtuals.append(VirtualServer(**v))
     test_iapps = []
     for i in big_ip.bigip_data['iapps']:
-        test_iapps.append(ApplicationService(**i))
+        test_iapps.append(IcrApplicationService(**i))
     test_nodes = []
     for n in big_ip.bigip_data['nodes']:
         test_nodes.append(Node(**n))


### PR DESCRIPTION
Moved the formatting of the iApp data from the Container Connectors
to CCCL and simplified the CCCL schema for iApps.