### PR TITLE
Remove immutable parameters from update operation

### DIFF
--- a/f5_cccl/resource/ltm/node.py
+++ b/f5_cccl/resource/ltm/node.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+from copy import deepcopy
 import logging
 
 from f5_cccl.resource import Resource
@@ -69,3 +70,9 @@ class Node(Resource):
 
     def _uri_path(self, bigip):
         return bigip.tm.ltm.nodes.node
+
+    def update(self, bigip, data=None, modify=False):
+        # 'address' is immutable, don't pass it in an update operation
+        tmp_data = deepcopy(data) if data is not None else deepcopy(self.data)
+        tmp_data.pop('address', None)
+        super(Node, self).update(bigip, data=tmp_data, modify=modify)

--- a/f5_cccl/resource/ltm/test/test_node.py
+++ b/f5_cccl/resource/ltm/test/test_node.py
@@ -15,9 +15,10 @@
 #
 
 from copy import copy
+from f5_cccl.resource import Resource
 from f5_cccl.resource.ltm.node import Node
 from f5_cccl.resource.ltm.pool import Pool
-from mock import Mock
+from mock import Mock, patch
 import pytest
 
 
@@ -44,6 +45,18 @@ def test_create_node():
     # verify all cfg items
     for k,v in cfg_test.items():
         assert node.data[k] == v
+
+
+def test_update_node():
+    node = Node(**cfg_test)
+
+    assert 'address' in node.data
+
+    # Verify that immutable 'address' is not passed to parent method
+    with patch.object(Resource, 'update') as mock_method:
+        node.update(bigip)
+        assert 1 == mock_method.call_count
+        assert 'address' not in mock_method.call_args[1]['data']
 
 
 def test_hash():

--- a/f5_cccl/resource/ltm/test/test_virtual_address.py
+++ b/f5_cccl/resource/ltm/test/test_virtual_address.py
@@ -15,9 +15,10 @@
 #
 
 from copy import deepcopy
-from mock import Mock
+from mock import Mock, patch
 import pytest
 
+from f5_cccl.resource import Resource
 from f5_cccl.resource.ltm.virtual_address import VirtualAddress
 
 va_cfg = {
@@ -66,6 +67,18 @@ def test_create_virtual_address_defaults():
     assert not data['enabled']
     assert not data['description']
     assert data['trafficGroup'] ==  "/Common/traffic-group-1"
+
+
+def test_update_virtual_address():
+    va = VirtualAddress(**va_cfg)
+
+    assert 'address' in va.data
+
+    # Verify that immutable 'address' is not passed to parent method
+    with patch.object(Resource, 'update') as mock_method:
+        va.update(bigip)
+        assert 1 == mock_method.call_count
+        assert 'address' not in mock_method.call_args[1]['data']
 
 
 def test_equals_virtual_address():

--- a/f5_cccl/resource/ltm/virtual_address.py
+++ b/f5_cccl/resource/ltm/virtual_address.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+from copy import deepcopy
 import logging
 
 from f5_cccl.resource import Resource
@@ -48,6 +49,12 @@ class VirtualAddress(Resource):
 
     def _uri_path(self, bigip):
         return bigip.tm.ltm.virtual_address_s.virtual_address
+
+    def update(self, bigip, data=None, modify=False):
+        # 'address' is immutable, don't pass it in an update operation
+        tmp_data = deepcopy(data) if data is not None else deepcopy(self.data)
+        tmp_data.pop('address', None)
+        super(VirtualAddress, self).update(bigip, data=tmp_data, modify=modify)
 
 
 class IcrVirtualAddress(VirtualAddress):


### PR DESCRIPTION
BIG-IP v11.6.1 does not allow immutable parameters to be present in an
'update' operation. Removed the 'address' field from updates to Virtual
Addresses and Nodes.