### PR TITLE
Add perf tests for simple operations involving BIG-IP

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -7,6 +7,7 @@ PyJWT==1.4.0
 mock==2.0.0
 pytest==3.0.5
 pytest-cov>=2.2.1
+pytest-benchmark==3.1.1
 python-coveralls==2.7.0
 pyOpenSSL==16.2.0
 requests-mock==1.2.0

--- a/test/f5_cccl/conftest.py
+++ b/test/f5_cccl/conftest.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import requests
+
+from mock import MagicMock
+
+from f5_cccl.api import F5CloudServiceManager
+
+from f5.bigip import ManagementRoot
+
+from icontrol.exceptions import iControlUnexpectedHTTPError
+
+requests.packages.urllib3.disable_warnings()
+
+
+def _wrap_instrument(f, counters, name):
+    def instrumented(*args, **kwargs):
+        #pytest.set_trace()
+        counters[name] += 1
+        return f(*args, **kwargs)
+    return instrumented
+
+def instrument_bigip(mgmt_root):
+    icr = mgmt_root.__dict__['_meta_data']['icr_session']
+    counters = {}
+    mgmt_root.test_rest_calls = counters
+
+    for method in ['get', 'put', 'delete', 'patch', 'post']:
+        counters[method] = 0
+        orig = getattr(icr.session, method)
+        instrumented = _wrap_instrument(orig, counters, method)
+        setattr(icr.session, method, instrumented)
+    return mgmt_root
+
+@pytest.fixture(scope="module")
+def bigip():
+    if pytest.symbols:
+        hostname = pytest.symbols.bigip_mgmt_ip
+        username = pytest.symbols.bigip_username
+        password = pytest.symbols.bigip_password
+
+        bigip_fix = ManagementRoot(hostname, username, password)
+        bigip_fix = instrument_bigip(bigip_fix)
+    else:
+        bigip_fix = MagicMock()
+
+    yield bigip_fix
+
+@pytest.fixture(scope="function")
+def bigip_rest_counters(bigip):
+    #icr = mgmt_root.__dict__['_meta_data']['icr_session']
+    counters = bigip.test_rest_calls
+    for k in counters.keys():
+        counters[k] = 0
+
+    yield counters
+
+    for k in counters.keys():
+        counters[k] = 0
+
+@pytest.fixture(scope="function")
+def partition(bigip):
+    name = "Test1"
+    partition = None
+
+    try:
+        bigip.tm.ltm.virtuals.virtual.load(
+            name="test_virtual", partition="Test1").delete()
+    except iControlUnexpectedHTTPError as icr_error:
+        pass
+    try:
+        bigip.tm.sys.folders.folder.load(name="Test1").delete()
+    except iControlUnexpectedHTTPError as icr_error:
+        pass
+
+    try:
+        partition = bigip.tm.sys.folders.folder.create(subPath="/", name=name)
+    except iControlUnexpectedHTTPError as icr_error:
+        code = icr_error.response.status_code
+        if code == 400:
+            print("Can't create partition {}".format(name))
+        elif code == 409:
+            print("Partition {} already exists".format(name))
+            partition = bigip.tm.sys.folders.folder.load(subPath="/", name=name)
+        else:
+            print("Unknown error creating partition.")
+        print(icr_error)
+
+    yield name
+
+    for pool in bigip.tm.ltm.pools.get_collection():
+        if pool.partition == name:
+            pool.delete()
+    for virtual in bigip.tm.ltm.virtuals.get_collection():
+        if virtual.partition == name:
+            virtual.delete()
+    partition.delete()
+
+
+@pytest.fixture(scope="function")
+def cccl(bigip, partition):
+    cccl = F5CloudServiceManager(bigip, partition)
+    yield cccl
+    cccl.apply_config({})
+
+
+@pytest.fixture()
+def pool(bigip, partition):
+    name = "pool1"
+    partition = partition
+    model = {'name': name, 'partition': partition}
+
+    try:
+        pool = bigip.tm.ltm.pools.pool.create(**model)
+    except iControlUnexpectedHTTPError as icr_error:
+        code = icr_error.response.status_code
+        if code == 400:
+            print("Can't create pool {}".format(name))
+        elif code == 409:
+            print("Pool {} already exists".format(name))
+            partition = bigip.tm.ltm.pools.pool.load(partition=partition,
+                                                     name=name)
+        else:
+            print("Unknown error creating pool.")
+        print(icr_error)
+
+    yield name
+
+    pool.delete()

--- a/test/f5_cccl/conftest.py
+++ b/test/f5_cccl/conftest.py
@@ -31,7 +31,6 @@ requests.packages.urllib3.disable_warnings()
 
 def _wrap_instrument(f, counters, name):
     def instrumented(*args, **kwargs):
-        #pytest.set_trace()
         counters[name] += 1
         return f(*args, **kwargs)
     return instrumented
@@ -48,6 +47,7 @@ def instrument_bigip(mgmt_root):
         setattr(icr.session, method, instrumented)
     return mgmt_root
 
+
 @pytest.fixture(scope="module")
 def bigip():
     if pytest.symbols:
@@ -62,9 +62,9 @@ def bigip():
 
     yield bigip_fix
 
+
 @pytest.fixture(scope="function")
 def bigip_rest_counters(bigip):
-    #icr = mgmt_root.__dict__['_meta_data']['icr_session']
     counters = bigip.test_rest_calls
     for k in counters.keys():
         counters[k] = 0
@@ -74,18 +74,20 @@ def bigip_rest_counters(bigip):
     for k in counters.keys():
         counters[k] = 0
 
+
 @pytest.fixture(scope="function")
 def partition(bigip):
     name = "Test1"
     partition = None
 
+    # Cleanup partition, in case previous runs were interrupted
     try:
         bigip.tm.ltm.virtuals.virtual.load(
-            name="test_virtual", partition="Test1").delete()
+            name="test_virtual", partition=name).delete()
     except iControlUnexpectedHTTPError as icr_error:
         pass
     try:
-        bigip.tm.sys.folders.folder.load(name="Test1").delete()
+        bigip.tm.sys.folders.folder.load(name=name).delete()
     except iControlUnexpectedHTTPError as icr_error:
         pass
 

--- a/test/f5_cccl/perf/test_perf.py
+++ b/test/f5_cccl/perf/test_perf.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from copy import deepcopy
+import pytest
+import requests
+import pdb
+
+from mock import MagicMock
+
+from f5.bigip import ManagementRoot
+
+from f5.sdk_exception import F5SDKError
+from icontrol.exceptions import iControlUnexpectedHTTPError
+
+import f5_cccl.exceptions as exceptions
+from f5_cccl.resource.ltm.virtual import VirtualServer
+
+from pprint import pprint
+
+requests.packages.urllib3.disable_warnings()
+
+req_symbols = ['bigip_mgmt_ip', 'bigip_username', 'bigip_password']
+def missing_bigip_symbols():
+    for sym in req_symbols:
+        if not hasattr(pytest.symbols, sym):
+            return True
+    return False
+
+pytestmark = pytest.mark.skipif(missing_bigip_symbols(),
+                                reason="Need symbols pointing at a real bigip.")
+
+def _make_svc_config(partition, num_virtuals=0, num_members=0):
+    base_virtual = {
+        'name': 'Virtual-1',
+        'destination': '/Test/1.2.3.4:80',
+        'ipProtocol': 'tcp',
+        'profiles': [
+            {'name': "tcp",
+            'partition': "Common",
+            'context': "all"}
+        ],
+        "enabled": True,
+        "vlansEnabled": True,
+        "sourceAddressTranslation": {
+        "type": "automap",
+        }
+    }
+    base_pool = {
+        "name": "pool1",
+        "monitors": ["/Common/http"]
+    },
+    base_member ={
+        "address": "172.16.0.100", "port": 8080, "routeDomain": {"id": 0}
+    }
+
+
+    cfg={
+        'virtualServers': [],
+        'pools': [],
+    }
+    for i in range(num_virtuals):
+        v = {}
+        v.update(base_virtual)
+        v['name'] = "virtual-{}".format(i)
+        v['pool'] = "/{}/pool-{}".format(partition,i)
+        cfg['virtualServers'].append(v)
+
+        p = {}
+        p.update(base_pool)
+        p['name'] = "pool-{}".format(i)
+
+        members = []
+        for i in range(num_members):
+            m = {}
+            m.update(base_member)
+            m['address'] = '172.16.0.{}'.format(i)
+            members.append(m)
+        p['members'] = members
+        cfg['pools'].append(p)
+
+    return cfg
+
+testdata = [
+    (1, 1),
+    (10, 10),
+    (100, 10),
+    (10, 100),
+]
+
+
+
+@pytest.mark.parametrize("nv,nm", testdata)
+@pytest.mark.benchmark(group="apply-new")
+def test_apply_new(partition, cccl, bigip_rest_counters, benchmark, nv, nm):
+    cfg = _make_svc_config(partition, num_virtuals=nv, num_members=nm)
+    def setup():
+        cccl.apply_config({})
+    def apply():
+        cccl.apply_config(cfg)
+    benchmark.pedantic(apply, setup=setup, rounds=2, iterations=1)
+
+    pprint(bigip_rest_counters)
+
+@pytest.mark.parametrize("nv,nm", testdata)
+@pytest.mark.benchmark(group="apply-no-change")
+def test_apply_no_change(partition, cccl, bigip_rest_counters, benchmark, nv, nm):
+    cfg = _make_svc_config(partition, num_virtuals=nv, num_members=nm)
+    def apply():
+        cccl.apply_config(cfg)
+    apply()
+    benchmark.pedantic(apply, rounds=2, iterations=1)
+    pprint(bigip_rest_counters)

--- a/test/f5_cccl/resource/ltm/policy/test_policy.py
+++ b/test/f5_cccl/resource/ltm/policy/test_policy.py
@@ -122,69 +122,6 @@ conditions = {
 }
 
 
-@pytest.fixture(scope="module", autouse=True)
-def bigip():
-
-    if pytest.symbols:
-        hostname = pytest.symbols.bigip_mgmt_ip
-        username = pytest.symbols.bigip_username
-        password = pytest.symbols.bigip_password
-
-        bigip = ManagementRoot(hostname, username, password)
-
-    else:
-        bigip = MagicMock()
-
-    yield bigip
-
-
-@pytest.fixture()
-def partition(bigip):
-    name="Test1"
-    partition = None
-
-    try:
-        partition = bigip.tm.sys.folders.folder.create(subPath="/", name=name)
-    except iControlUnexpectedHTTPError as icr_error:
-        code = icr_error.response.status_code
-        if code == 400:
-            print("Can't create partition {}".format(name))
-        elif code == 409:
-            print("Partition {} already exists".format(name))
-            partition = bigip.tm.sys.folders.folder.load(subPath="/", name=name)
-        else:
-            print("Unknown error creating partition.")
-        print(icr_error)
-
-    yield name
-
-    partition.delete()
-
-
-@pytest.fixture()
-def pool(bigip, partition):
-    name="pool1"
-    partition = partition
-    model = {'name': name, 'partition': partition}
-
-    try:
-        pool = bigip.tm.ltm.pools.pool.create(**model)
-    except iControlUnexpectedHTTPError as icr_error:
-        code = icr_error.response.status_code
-        if code == 400:
-            print("Can't create pool {}".format(name))
-        elif code == 409:
-            print("Pool {} already exists".format(name))
-            partition = bigip.tm.ltm.pools.pool.load(partition=partition, name=name)
-        else:
-            print("Unknown error creating pool.")
-        print(icr_error)
-
-    yield name
-
-    pool.delete()
-
-
 class TestPolicy(object):
 
     name = "test_policy"


### PR DESCRIPTION
Add a simple benchmark test to measure how long it takes to apply() simple configurations of various sizes.

These tests will be skipped if there are no big-ip credentials defined.