### PR TITLE
Update version of k8s-bigip-ctlr used for regression tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - REPO="f5-cccl"
     - PKG_VERSION=$(python -c "import f5_cccl; print f5_cccl.__version__")
     - MARATHON_BIGIP_CTLR_COMMIT_ISH=a7b291ec13099b51da02f414cff3a7d5632d56a3
-    - K8S_BIGIP_CTLR_COMMIT_ISH=fdc7919aac8f24d461dd2bd7d55e0840deb208d0
+    - K8S_BIGIP_CTLR_COMMIT_ISH=dc8b4d608ec37226ce3c25fc804eacb4441c75eb
 services:
    - docker
 before_install:


### PR DESCRIPTION
Point to controller top-of-tree SHA.