### PR TITLE
Delete non-legacy policies

### DIFF
--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -180,12 +180,17 @@ class BigIPProxy(object):
         if policy.status != 'legacy':
             for v in virtuals:
                 # First, remove non-legacy policies from virtuals
-                policies = [
-                    p for p in v.policiesReference.get('items', [])
-                    if p['name'] != policy.name
-                ]
-                v.policiesReference['items'] = policies
-                v.update()
+                policies = []
+                policy_delete = False
+                for p in v.policiesReference.get('items', []):
+                    if p['name'] == policy.name:
+                        policy_delete = True
+                    else:
+                        policies.append(p)
+
+                if policy_delete:
+                    v.policiesReference['items'] = policies
+                    v.update()
 
             # delete policy
             policy.delete()


### PR DESCRIPTION
CCCL only supports 'legacy' mode for policies, because published
policies can't be updated. If a non-legacy policy is detected on
BIG-IP, the policy will be removed from any Virtual Servers that
reference it and the policy will be deleted.