### PR TITLE
CCCL incompatible with BIG-IP v11.6.1 policies

### DIFF
--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -177,7 +177,7 @@ class BigIPProxy(object):
 
     def _policy_status_check(self, policy, virtuals):
         """Delete non-legacy policies because they can't be updated."""
-        if policy.status != 'legacy':
+        if getattr(policy, 'status', 'legacy') != 'legacy':
             for v in virtuals:
                 # First, remove non-legacy policies from virtuals
                 policies = []

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,7 +1,7 @@
 git+https://github.com/F5Networks/pytest-symbols.git
 
 # Test Requirements
-f5-sdk==3.0.2
+f5-sdk==3.0.3
 ipaddress==1.0.17
 PyJWT==1.4.0
 mock==2.0.0

--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -1,5 +1,5 @@
 # F5-CCCL Install Requirements
-f5-sdk==3.0.2
+f5-sdk==3.0.3
 ipaddress==1.0.17
 netaddr==0.7.19
 PyJWT==1.4.0


### PR DESCRIPTION
Incompatibility with policy rules fixed in f5-sdk 3.0.3, update
requirements to point to new sdk version.