### PR TITLE
Added full route domain support

### DIFF
--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -34,7 +34,7 @@ from f5_cccl.resource.ltm.policy import IcrPolicy
 from f5_cccl.resource.ltm.pool import IcrPool
 from f5_cccl.resource.ltm.virtual_address import IcrVirtualAddress
 from f5_cccl.resource.ltm.virtual import IcrVirtualServer
-from f5_cccl.resource.ltm.node import Node
+from f5_cccl.resource.ltm.node import IcrNode
 from f5_cccl.resource.ltm.irule import IcrIRule
 from f5_cccl.resource.ltm.internal_data_group import IcrInternalDataGroup
 
@@ -147,7 +147,8 @@ class BigIPProxy(object):
             raise cccl_exc.F5CcclCacheRefreshError(
                 "BigIPProxy: failed to refresh internal BIG-IP state.")
 
-    def _create_resource(self, resource_type, resource_obj):
+    def _create_resource(self, resource_type, resource_obj,
+                         default_route_domain=None):
         """Create an iControl REST resource and handle exceptions on init.
 
         If some error occurs during the creation of a resource object,
@@ -159,7 +160,13 @@ class BigIPProxy(object):
         """
         icr_resource = None
         try:
-            icr_resource = resource_type(**resource_obj.raw)
+            if default_route_domain is not None:
+                icr_resource = resource_type(
+                    default_route_domain=default_route_domain,
+                    **resource_obj.raw)
+            else:
+                icr_resource = resource_type(**resource_obj.raw)
+
         except (ValueError, TypeError) as error:
             LOGGER.error(
                 "Failed to create iControl REST resource %s, %s: error(%s)",
@@ -183,6 +190,9 @@ class BigIPProxy(object):
 
         #  Retrieve the list of virtual servers in managed partition.
         query = partition_filter
+
+        #  Determine the current route domain default for the partition
+        default_route_domain = self.get_default_route_domain()
 
         #  Retrieve the lists of health monitors
         LOGGER.debug("Retrieving http_monitors from BIG-IP /%s...",
@@ -302,7 +312,7 @@ class BigIPProxy(object):
 
         #  Refresh the node cache
         self._nodes = {
-            n.name: self._create_resource(Node, n)
+            n.name: self._create_resource(IcrNode, n, default_route_domain)
             for n in nodes
         }
 
@@ -326,6 +336,14 @@ class BigIPProxy(object):
 
         LOGGER.debug(
             "BIG-IP refresh took %.5f seconds.", (time() - start_time))
+
+    def get_default_route_domain(self):
+        """Return the configured default route domain for the partition"""
+        partition = self._bigip.tm.auth.partitions.partition.load(
+            name=self._partition)
+        # Note: This information is needed when processing the request config
+        #       which occurs before self.refresh() is called
+        return partition.defaultRouteDomain
 
     def get_virtuals(self, all_virtuals=False):
         """Return the index of virtual servers."""

--- a/f5_cccl/resource/ltm/pool.py
+++ b/f5_cccl/resource/ltm/pool.py
@@ -102,7 +102,7 @@ class Pool(Resource):
 
 class ApiPool(Pool):
     """Parse the CCCL input to create the canonical Pool."""
-    def __init__(self, name, partition, **properties):
+    def __init__(self, name, partition, default_route_domain, **properties):
         """Parse the CCCL schema input."""
         pool_config = dict()
         for k, v in properties.items():
@@ -111,7 +111,8 @@ class ApiPool(Pool):
             pool_config[k] = v
 
         members_config = properties.get('members', None)
-        members = self._get_members(partition, members_config)
+        members = self._get_members(partition, default_route_domain,
+                                    members_config)
 
         monitors_config = properties.pop('monitors', None)
         pool_config['monitor'] = self._get_monitors(monitors_config)
@@ -120,15 +121,16 @@ class ApiPool(Pool):
                                       members,
                                       **pool_config)
 
-    def _get_members(self, partition, members):
+    def _get_members(self, partition, default_route_domain, members):
         """Get a list of members from the pool definition"""
         members_list = list()
         if members:
             for member in members:
-                m = ApiPoolMember(name=None,
-                                  partition=partition,
-                                  pool=self,
-                                  **member)
+                m = ApiPoolMember(
+                    partition=partition,
+                    default_route_domain=default_route_domain,
+                    pool=self,
+                    **member)
                 members_list.append(m)
 
         return members_list

--- a/f5_cccl/resource/ltm/pool_member.py
+++ b/f5_cccl/resource/ltm/pool_member.py
@@ -20,6 +20,7 @@ import logging
 import re
 
 from f5_cccl.resource import Resource
+from f5_cccl.utils.route_domain import normalize_address_with_route_domain
 from netaddr import IPAddress
 from requests.utils import quote as urlquote
 
@@ -46,7 +47,6 @@ class PoolMember(Resource):
 
     def __init__(self, name, partition, pool=None, **properties):
         """Initialize the PoolMember object."""
-        name = self._strip_route_domain_zero(name)
         super(PoolMember, self).__init__(name, partition)
 
         self._pool = pool
@@ -85,19 +85,6 @@ class PoolMember(Resource):
         return ("monitor" in self.data['session'] or
                 "monitor" in other_session)
 
-    def _strip_route_domain_zero(self, name):
-        """Remove the route domain from the address, if 0."""
-        match = self.member_name_re.match(name)
-        if match and match.group(2) == "0":
-            ip_address = IPAddress(match.group(1))
-            if ip_address.version == 4:
-                name = "{}:{}".format(
-                    match.group(1), match.group(3))
-            else:
-                name = "{}.{}".format(
-                    match.group(1), match.group(3))
-        return name
-
     def _uri_path(self, bigip):
         if not self._pool:
             LOGGER.error(
@@ -123,35 +110,29 @@ class IcrPoolMember(PoolMember):
 
 class ApiPoolMember(PoolMember):
     """PoolMember instantiated from F5 CCCL schema input."""
-    def __init__(self, name, partition, pool=None, **properties):
+
+    def __init__(self, partition, default_route_domain, pool, **properties):
         u"""Create a PoolMember instance from CCCL PoolMemberType.
 
         Args:
-            name (string): The name of the member <address>:<port>
             If this is defined as None, the name will be computed
             from the address and port.
             partition (string): Pool member partition
+            default_route_domain (string): For managed partition
             pool (Pool): Parent pool object
 
         Properties:
             address (string): Member IP address
             port (int): Member service port
-            routeDomain (dict): Route domain id and name
             ratio (int): Member weight for ratio-member lb algorithm
             connectionLimit (int): Max number of connections
             priorityGroup (int): Member priority group
             state (string): Member admin state, user-up or user-down
             description (string): User specified description
         """
-        if not name:
-            address = properties.get('address', None)
-            port = properties.get('port', None)
-            route_domain = properties.get('routeDomain', {})
-
-            name = self._init_member_name(
-                address,
-                port,
-                route_domain)
+        address = properties.get('address', None)
+        port = properties.get('port', None)
+        name = self._init_member(address, port, default_route_domain)
 
         super(ApiPoolMember, self).__init__(name=name,
                                             partition=partition,
@@ -159,11 +140,11 @@ class ApiPoolMember(PoolMember):
                                             **properties)
 
     @staticmethod
-    def _init_member_name(address, port, route_domain):
-        u"""Initialize the pool member address.
+    def _init_member(address, port, default_route_domain):
+        u"""Initialize the pool member name and address.
 
         An address is of the form:
-        <ip_address>%<route_domain_id>
+        <ip_address>[%<route_domain_id>]
         """
         if not address or not port:
             LOGGER.error(
@@ -171,19 +152,17 @@ class ApiPoolMember(PoolMember):
             raise TypeError(
                 "F5CCCL poolMember definition must contain address and port")
 
-        ip_address = IPAddress(address)
-        rd_id = route_domain.get('id', 0)
-        if rd_id:
-            if ip_address.version == 4:
-                name_format = "{}%{}:{}"
-            else:
-                name_format = "{}%{}.{}"
-            name = name_format.format(address, rd_id, port)
+        # force address to include route domain
+        address, ip, _ = normalize_address_with_route_domain(
+            address, default_route_domain)
+
+        ip_address = IPAddress(ip)
+
+        # force name to be defined as <ip>%<rd>:<port>
+        if ip_address.version == 4:
+            name_format = "{}:{}"
         else:
-            if ip_address.version == 4:
-                name_format = "{}:{}"
-            else:
-                name_format = "{}.{}"
-            name = name_format.format(address, port)
+            name_format = "{}.{}"
+        name = name_format.format(address, port)
 
         return name

--- a/f5_cccl/resource/ltm/test/test_api_pool_member.py
+++ b/f5_cccl/resource/ltm/test/test_api_pool_member.py
@@ -32,36 +32,26 @@ def members():
             'port': 80
         },
         'member_w_route_domain': {
-            'address': "172.16.200.101",
+            'address': "172.16.200.101%0",
             'port': 80,
-            'routeDomain': {'id': 0}
         },
         'member_no_port': {
             'address': "172.16.200.102",
-            'routeDomain': {'id': 0}
         },
         'member_no_address': {
             'port': 80,
-            'routeDomain': {'id': 0}
         },
         'member_w_nonzero_route_domain': {
-            'address': "172.16.200.103",
+            'address': "172.16.200.103%2",
             'port': 80,
-            'routeDomain': {'id': 2}
         },
         'member_min_ipv6_config': {
             'address': "2001:0db8:3c4d:0015:0000:0000:abcd:ef12",
             'port': 80
         },
         'member_min_ipv6_rd_config': {
-            'address': "2001:0db8:3c4d:0015:0000:0000:abcd:ef12",
+            'address': "2001:0db8:3c4d:0015:0000:0000:abcd:ef12%2",
             'port': 80,
-            'routeDomain': {'id': 2}
-        },
-        'member_min_config_w_name': {
-            'address': "172.16.200.100",
-            'port': 80,
-            'name': "192.168.200.100:80"
         }
     }
     return members
@@ -90,8 +80,8 @@ def test_create_cccl_member_min_config(pool, members):
 
     # pdb.set_trace()
     member = ApiPoolMember(
-        name=None,
         partition=partition,
+        default_route_domain=0,
         pool=pool,
         **members[cfg_name]
     )
@@ -103,7 +93,7 @@ def test_create_cccl_member_min_config(pool, members):
     pool_data = copy.copy(member.data)
     for k, _ in POOL_PROPERTIES.items():
         if k == 'name':
-            assert pool_data['name'] == "172.16.200.100:80"
+            assert pool_data['name'] == "172.16.200.100%0:80"
         elif k == 'partition':
             assert pool_data['partition'] == "Common"
         elif k == 'ratio':
@@ -127,8 +117,8 @@ def test_create_cccl_member_w_route_domain(pool, members):
     partition = "Common"
 
     member = ApiPoolMember(
-        name=None,
         partition=partition,
+        default_route_domain=0,
         pool=pool,
         **members[cfg_name]
     )
@@ -140,7 +130,7 @@ def test_create_cccl_member_w_route_domain(pool, members):
     pool_data = copy.copy(member.data)
     for k, _ in POOL_PROPERTIES.items():
         if k == 'name':
-            assert pool_data['name'] == "172.16.200.101:80"
+            assert pool_data['name'] == "172.16.200.101%0:80"
         elif k == 'partition':
             assert pool_data['partition'] == "Common"
         elif k == 'ratio':
@@ -165,8 +155,8 @@ def test_create_cccl_member_no_port(pool, members):
 
     with pytest.raises(TypeError):
         member = ApiPoolMember(
-            name=None,
             partition=partition,
+            default_route_domain=0,
             pool=pool,
             **members[cfg_name]
         )
@@ -180,8 +170,8 @@ def test_create_cccl_member_no_address(pool, members):
 
     with pytest.raises(TypeError):
         member = ApiPoolMember(
-            name=None,
             partition=partition,
+            default_route_domain=0,
             pool=pool,
             **members[cfg_name]
         )
@@ -194,8 +184,8 @@ def test_create_cccl_member_w_nonzero_route_domain(pool, members):
     partition = "Common"
 
     member = ApiPoolMember(
-        name=None,
         partition=partition,
+        default_route_domain=0,
         pool=pool,
         **members[cfg_name]
     )
@@ -232,8 +222,8 @@ def test_create_cccl_member_min_ipv6_config(pool, members):
 
     # pdb.set_trace()
     member = ApiPoolMember(
-        name=None,
         partition=partition,
+        default_route_domain=0,
         pool=pool,
         **members[cfg_name]
     )
@@ -246,7 +236,7 @@ def test_create_cccl_member_min_ipv6_config(pool, members):
     for k, _ in POOL_PROPERTIES.items():
         if k == 'name':
             assert (pool_data['name'] ==
-                    "2001:0db8:3c4d:0015:0000:0000:abcd:ef12.80")
+                    "2001:0db8:3c4d:0015:0000:0000:abcd:ef12%0.80")
         elif k == 'partition':
             assert pool_data['partition'] == "Common"
         elif k == 'ratio':
@@ -271,8 +261,8 @@ def test_create_cccl_member_min_ipv6_rd_config(pool, members):
 
     # pdb.set_trace()
     member = ApiPoolMember(
-        name=None,
         partition=partition,
+        default_route_domain=0,
         pool=pool,
         **members[cfg_name]
     )
@@ -286,43 +276,6 @@ def test_create_cccl_member_min_ipv6_rd_config(pool, members):
         if k == 'name':
             assert (pool_data['name'] ==
                     "2001:0db8:3c4d:0015:0000:0000:abcd:ef12%2.80")
-        elif k == 'partition':
-            assert pool_data['partition'] == "Common"
-        elif k == 'ratio':
-            assert pool_data['ratio'] == 1
-        elif k == 'connectionLimit':
-            assert pool_data['connectionLimit'] == 0
-        elif k == 'priorityGroup':
-            assert pool_data['priorityGroup'] == 0
-        elif k == 'session':
-            assert pool_data['session'] == "user-enabled"
-        elif k == 'description':
-            assert not pool_data['description']
-        pool_data.pop(k)
-
-    assert not pool_data, "unexpected keys found in data"
-
-
-def test_create_cccl_member_min_config_w_name(pool, members):
-    """Test of ApiPoolMember create with a name."""
-    cfg_name = "member_min_config_w_name"
-    partition = "Common"
-
-    # pdb.set_trace()
-    member = ApiPoolMember(
-        partition=partition,
-        pool=pool,
-        **members[cfg_name]
-    )
-
-    assert member
-
-    # Test data
-    assert member.data
-    pool_data = copy.copy(member.data)
-    for k, _ in POOL_PROPERTIES.items():
-        if k == 'name':
-            assert pool_data['name'] == "192.168.200.100:80"
         elif k == 'partition':
             assert pool_data['partition'] == "Common"
         elif k == 'ratio':

--- a/f5_cccl/resource/ltm/test/test_node.py
+++ b/f5_cccl/resource/ltm/test/test_node.py
@@ -23,9 +23,9 @@ import pytest
 
 
 cfg_test = {
-    'name': '1.2.3.4%0',
+    'name': '1.2.3.4%2',
     'partition': 'my_partition',
-    'address': '1.2.3.4'
+    'address': '1.2.3.4%2'
 }
 
 
@@ -38,17 +38,21 @@ def bigip():
 def test_create_node():
     """Test Node creation."""
     node = Node(
+        default_route_domain=2,
         **cfg_test
     )
     assert node
 
     # verify all cfg items
     for k,v in cfg_test.items():
-        assert node.data[k] == v
+        assert node._data[k] == v
 
 
 def test_update_node():
-    node = Node(**cfg_test)
+    node = Node(
+        default_route_domain=2,
+        **cfg_test
+    )
 
     assert 'address' in node.data
 
@@ -62,19 +66,23 @@ def test_update_node():
 def test_hash():
     """Test Node Server hash."""
     node = Node(
+        default_route_domain=2,
         **cfg_test
     )
     node1 = Node(
+        default_route_domain=2,
         **cfg_test
     )
     cfg_changed = copy(cfg_test)
     cfg_changed['name'] = 'test'
     node2 = Node(
+        default_route_domain=2,
         **cfg_changed
     )
     cfg_changed = copy(cfg_test)
     cfg_changed['partition'] = 'other'
     node3 = Node(
+        default_route_domain=2,
         **cfg_changed
     )
     assert node
@@ -93,9 +101,11 @@ def test_eq():
     name = 'node_1'
 
     node = Node(
+        default_route_domain=2,
         **cfg_test
     )
     node2 = Node(
+        default_route_domain=2,
         **cfg_test
     )
     pool = Pool(
@@ -129,12 +139,13 @@ def test_eq():
     assert node != node2
 
     # different objects
-    assert node != pool 
+    assert node != pool
 
 
 def test_uri_path(bigip):
     """Test Node URI."""
     node = Node(
+        default_route_domain=2,
         **cfg_test
     )
     assert node

--- a/f5_cccl/resource/ltm/test/test_pool.py
+++ b/f5_cccl/resource/ltm/test/test_pool.py
@@ -33,14 +33,14 @@ bigip_pools_cfg = [
          'isSubcollection': True,
          'items': [
              {'ratio': 1,
-              'name': '172.16.0.100:8080',
+              'name': '172.16.0.100%0:8080',
               'partition': 'Common',
               'session': 'monitor-enabled',
               'priorityGroup': 0,
               'connectionLimit': 0,
               'description': None},
              {'ratio': 1,
-              'name': '172.16.0.101:8080',
+              'name': '172.16.0.101%0:8080',
               'partition': 'Common',
               'session': 'monitor-enabled',
               'priorityGroup': 0,
@@ -62,15 +62,15 @@ cccl_pools_cfg = [
     { "name": "pool0" },
     { "name": "pool1",
       "members": [
-          {"address": "172.16.0.100", "port": 8080, "routeDomain": {"id": 0}},
-          {"address": "172.16.0.101", "port": 8080, "routeDomain": {"id": 0}}
+          {"address": "172.16.0.100%0", "port": 8080},
+          {"address": "172.16.0.101%0", "port": 8080}
       ],
       "monitors": ["/Common/http"]
     },
     { "name": "pool2",
       "members": [
-          {"address": "192.168.0.100", "port": 80, "routeDomain": {"id": 2}},
-          {"address": "192.168.0.101", "port": 80, "routeDomain": {"id": 2}}
+          {"address": "192.168.0.100", "port": 80},
+          {"address": "192.168.0.101", "port": 80}
       ],
       "monitors": []
     },
@@ -86,8 +86,8 @@ cccl_pools_cfg = [
     },
     { "name": "pool1",
       "members": [
-          {"address": "172.16.0.100", "port": 8080, "routeDomain": {"id": 0}},
-          {"address": "172.16.0.102", "port": 8080, "routeDomain": {"id": 0}}
+          {"address": "172.16.0.100", "port": 8080},
+          {"address": "172.16.0.102", "port": 8080}
       ],
       "monitors": ["/Common/http"]
     }
@@ -150,7 +150,7 @@ def bigip_members():
 
 
 def test_create_pool_minconfig(cccl_pool0):
-    pool = ApiPool(partition="Common", **cccl_pool0)
+    pool = ApiPool(partition="Common", default_route_domain=0, **cccl_pool0)
 
     assert pool.name == "pool0"
     assert pool.partition == "Common"
@@ -160,7 +160,7 @@ def test_create_pool_minconfig(cccl_pool0):
     assert pool.data['monitor'] == "default"
 
 def test_create_pool(cccl_pool1):
-    pool = ApiPool(partition="Common", **cccl_pool1)
+    pool = ApiPool(partition="Common", default_route_domain=0, **cccl_pool1)
 
     assert pool.name == "pool1"
     assert pool.partition == "Common"
@@ -172,7 +172,7 @@ def test_create_pool(cccl_pool1):
 
 
 def test_create_pool_empty_lists(cccl_pool3):
-    pool = ApiPool(partition="Common", **cccl_pool3)
+    pool = ApiPool(partition="Common", default_route_domain=0, **cccl_pool3)
 
     assert pool.name == "pool3"
     assert pool.partition == "Common"
@@ -183,34 +183,34 @@ def test_create_pool_empty_lists(cccl_pool3):
 
 
 def test_compare_equal_pools(cccl_pool0):
-    p1 = ApiPool(partition="Common", **cccl_pool0)
-    p2 = ApiPool(partition="Common", **cccl_pool0)
+    p1 = ApiPool(partition="Common", default_route_domain=0, **cccl_pool0)
+    p2 = ApiPool(partition="Common", default_route_domain=0, **cccl_pool0)
 
     assert id(p1) != id(p2)
     assert p1 == p2
 
 
 def test_compare_pool_and_dict(cccl_pool0):
-    pool = ApiPool(partition="Common", **cccl_pool0)
+    pool = ApiPool(partition="Common", default_route_domain=0, **cccl_pool0)
 
     assert not pool == cccl_pool0
 
 
 def test_get_uri_path(bigip, cccl_pool0):
-    pool = ApiPool(partition="Common", **cccl_pool0)
+    pool = ApiPool(partition="Common", default_route_domain=0, **cccl_pool0)
 
     assert pool._uri_path(bigip) == bigip.tm.ltm.pools.pool
 
 
 def test_pool_hash(bigip, cccl_pool0):
-    pool = ApiPool(partition="Common", **cccl_pool0)
+    pool = ApiPool(partition="Common", default_route_domain=0, **cccl_pool0)
 
     assert hash(pool) == hash((pool.name, pool.partition))
 
 
 def test_compare_bigip_cccl_pools(cccl_pool1, bigip_pool0):
     bigip_pool = IcrPool(**bigip_pool0)
-    cccl_pool = ApiPool(partition="Common", **cccl_pool1)
+    cccl_pool = ApiPool(partition="Common", default_route_domain=0, **cccl_pool1)
 
     assert bigip_pool == cccl_pool
 
@@ -224,29 +224,28 @@ def test_create_bigip_pool_no_members(bigip_pool1):
 
 
 def test_compare_pools_unequal_members(bigip, cccl_pool1, cccl_pool2, cccl_pool5):
-    pool1 = ApiPool(partition="Common", **cccl_pool1)
-    pool2 = ApiPool(partition="Common", **cccl_pool2)
-    pool5 = ApiPool(partition="Common", **cccl_pool5)
+    pool1 = ApiPool(partition="Common", default_route_domain=0, **cccl_pool1)
+    pool2 = ApiPool(partition="Common", default_route_domain=0, **cccl_pool2)
+    pool5 = ApiPool(partition="Common", default_route_domain=0, **cccl_pool5)
 
     pool1_one_member_cfg = { "name": "pool1",
       "members": [
-          {"address": "172.16.0.100", "port": 8080, "routeDomain": {"id": 0}},
+          {"address": "172.16.0.100", "port": 8080},
       ],
       "monitors": ["/Common/http"]
     }
     pool1_one_member = ApiPool(partition="Common",
-                                  **pool1_one_member_cfg)
+                               default_route_domain=0, **pool1_one_member_cfg)
 
 
     pool2_with_monitor = { "name": "pool2",
       "members": [
-          {"address": "192.168.0.100", "port": 80, "routeDomain": {"id": 2}},
-          {"address": "192.168.0.101", "port": 80, "routeDomain": {"id": 2}}
+          {"address": "192.168.0.100%2", "port": 80},
+          {"address": "192.168.0.101%2", "port": 80}
       ],
       "monitors": ["/Common/http"]
     }
-    pool2_with_monitor = ApiPool(partition="Common",
-                                 **pool2_with_monitor)
+    pool2_with_monitor = ApiPool(partition="Common", default_route_domain=0, **pool2_with_monitor)
 
     assert not pool1 == pool2
     assert pool1 != pool2
@@ -260,7 +259,7 @@ def test_compare_pools_unequal_members(bigip, cccl_pool1, cccl_pool2, cccl_pool5
 
 
 def test_get_monitors(bigip):
-    pool = ApiPool(name="pool1", partition="Common")
+    pool = ApiPool(name="pool1", default_route_domain=0, partition="Common")
 
     assert pool._get_monitors(None) == "default"
     assert pool._get_monitors([]) == "default"    

--- a/f5_cccl/resource/ltm/test/test_pool_member.py
+++ b/f5_cccl/resource/ltm/test/test_pool_member.py
@@ -27,12 +27,6 @@ from mock import MagicMock
 import pytest
 
 
-ccclMemberA = {
-    "address": "172.16.0.100", "port": 8080, "routeDomain": {"id": 0}}
-ccclMemberB = {
-    "address": "172.16.0.101", "port": 8080, "routeDomain": {"id": 0}}
-
-
 @pytest.fixture
 def pool_member_ipv6():
     pass
@@ -134,7 +128,7 @@ def test_create_pool_member_with_rd(pool, pool_member_with_rd):
 
     # Test data
     assert member.data
-    assert member.data['name'] == "192.168.100.101:80"
+    assert member.data['name'] == "192.168.100.101%0:80"
 
 
 def test_create_pool_member_with_rd_ipv6(pool, pool_member_with_rd_ipv6):
@@ -150,4 +144,4 @@ def test_create_pool_member_with_rd_ipv6(pool, pool_member_with_rd_ipv6):
 
     # Test data
     assert member.data
-    assert member.data['name'] == "2001:0db8:3c4d:0015:0000:0000:abcd:ef12.80"
+    assert member.data['name'] == "2001:0db8:3c4d:0015:0000:0000:abcd:ef12%0.80"

--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -85,18 +85,6 @@ definitions:
     required:
       - "name"
 
-  routeDomainType: 
-    type: "object"
-    description: "Defines the route domain name and id pair."
-    properties:
-      id: 
-        type: "integer"
-      name: 
-        type: "string"
-        default: ""
-    required: 
-      - "id"
-
   snatConfigType:
     type: "object"
     description: "Describes a SNAT configuration for virtual server."
@@ -442,7 +430,7 @@ definitions:
       name:
         type: "string"
         definition: >
-          Specifies the name of the pool member.  The default has the form: <address>:<port>
+          Specifies the name of the pool member.  The default has the form: <address>%<route_domain>:<port>
       connectionLimit:
         type: "integer"
         definition: >
@@ -464,13 +452,12 @@ definitions:
         default: "user-enabled"
       address:
         type: "string"
-        definition: "Specifies the IP address for the pool member."
+        definition: >
+          Specifies the IP address for the pool member. This is of the
+          form <ip_address>[%<route_domain>]
       port: 
         definition: "Specifies the service port for the pool member."
         $ref: "#/definitions/portType"
-      routeDomain:
-        definition: "Specifies the member IP address namespace."
-        $ref: "#/definitions/routeDomainType"
       priorityGroup: 
         type: "integer"
         definition: >
@@ -705,7 +692,7 @@ definitions:
           Specifies destination IP address information to which 
           the virtual server sends traffic.  This can be an IP address 
           or a previously created virtual-address.  This is of the
-          form /<partition>/<ip_address>%<route_domain>:<service_port>
+          form /<partition>/<ip_address>[%<route_domain>]:<service_port>
         type: "string"
 
       pool: 

--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -87,8 +87,8 @@
   "pools": [
     { "name": "pool2",
       "members": [
-        {"address": "172.16.0.100", "port": 8080, "routeDomain": {"id": 0}},
-        {"address": "172.16.0.101", "port": 8080, "routeDomain": {"id": 0}}
+        {"address": "172.16.0.100%1", "port": 8080},
+        {"address": "172.16.0.101", "port": 8080}
       ],
       "monitors": ["/test/myhttp"]
     }

--- a/f5_cccl/service/config_reader.py
+++ b/f5_cccl/service/config_reader.py
@@ -45,7 +45,8 @@ class ServiceConfigReader(object):
         """Initializer."""
         self._partition = partition
 
-    def _create_config_item(self, resource_type, obj):
+    def _create_config_item(self, resource_type, obj,
+                            default_route_domain=None):
         """Create an API resource object and handle exceptions.
 
         This is a factory method to create resource objects in
@@ -60,9 +61,15 @@ class ServiceConfigReader(object):
         """
         config_resource = None
         try:
-            config_resource = resource_type(
-                partition=self._partition,
-                **obj)
+            if default_route_domain is not None:
+                config_resource = resource_type(
+                    partition=self._partition,
+                    default_route_domain=default_route_domain,
+                    **obj)
+            else:
+                config_resource = resource_type(
+                    partition=self._partition,
+                    **obj)
         except (ValueError, TypeError) as error:
             msg_format = \
                 "Failed to create resource {}, {} from config: error({})"
@@ -73,7 +80,7 @@ class ServiceConfigReader(object):
 
         return config_resource
 
-    def read_config(self, service_config):
+    def read_config(self, service_config, default_route_domain):
         """Read the service configuration and save as resource object."""
         config_dict = dict()
         config_dict['http_monitors'] = dict()
@@ -98,7 +105,8 @@ class ServiceConfigReader(object):
 
         pools = service_config.get('pools', list())
         config_dict['pools'] = {
-            p['name']: self._create_config_item(ApiPool, p)
+            p['name']: self._create_config_item(ApiPool, p,
+                                                default_route_domain)
             for p in pools
         }
 

--- a/f5_cccl/service/manager.py
+++ b/f5_cccl/service/manager.py
@@ -25,13 +25,21 @@ import f5_cccl.exceptions as exc
 from f5_cccl.service.config_reader import ServiceConfigReader
 from f5_cccl.service.validation import ServiceConfigValidator
 from f5_cccl.resource.ltm.node import Node
+from f5_cccl.utils.route_domain import (
+    encoded_normalize_address_with_route_domain)
+from f5_cccl.utils.route_domain import split_ip_with_route_domain
 
 
 LOGGER = logging.getLogger(__name__)
 
 
+# Check for upgrade issues on first pass only
+
+
 class ServiceConfigDeployer(object):
     """CCCL config deployer class."""
+
+    first_pass = True
 
     def __init__(self, bigip_proxy):
         """Initialize the config deployer."""
@@ -52,7 +60,6 @@ class ServiceConfigDeployer(object):
             existing[resource] for resource in
             set(existing) - set(desired)
         ]
-
         return (create_list, update_list, delete_list)
 
     def _create_resources(self, create_list):
@@ -150,7 +157,7 @@ class ServiceConfigDeployer(object):
 
         return (create_monitors, update_monitors, delete_monitors)
 
-    def _desired_nodes(self):
+    def _desired_nodes(self, default_route_domain):
         """Desired nodes is inferred from the active pool members."""
         desired_nodes = dict()
 
@@ -158,21 +165,81 @@ class ServiceConfigDeployer(object):
         pools = self._bigip.get_pools(True)
         for pool in pools:
             for member in pools[pool].members:
-                addr = member.name.split('%3A')[0]
+                pool_addr = member.name.split('%3A')[0]
+                pool_addr_rd = encoded_normalize_address_with_route_domain(
+                    pool_addr, default_route_domain, True, False)
                 # make a copy to iterate over, then delete from 'nodes'
                 node_list = list(nodes.keys())
                 for key in node_list:
-                    if nodes[key].data['address'] == addr:
+                    node_addr = nodes[key].data['address']
+                    node_addr_rd = encoded_normalize_address_with_route_domain(
+                        node_addr, default_route_domain, False, False)
+                    if node_addr_rd == pool_addr_rd:
                         node = {'name': key,
                                 'partition': nodes[key].partition,
-                                'address': addr,
+                                'address': pool_addr_rd,
+                                'default_route_domain': default_route_domain,
                                 'state': 'user-up',
                                 'session': 'user-enabled'}
                         desired_nodes[key] = Node(**node)
 
         return desired_nodes
 
-    def _post_deploy(self, desired_config):
+    def _pre_deploy_legacy_cleanup(self):  # pylint: disable=too-many-locals
+        """Remove legacy named resources (pre Route Domain support)
+
+           We now node resource names to include the route domain whether
+           the end user specified them or not.  This prevents inconsistent
+           behavior when the default route domain is changed for the
+           managed partition.
+
+           This function can be removed when the cccl version >= 2.0
+        """
+
+        # Detect legacy names (nodes do not include the route domain)
+        self._bigip.refresh()
+        existing_nodes = self._bigip.get_nodes()
+        node_list = list(existing_nodes.keys())
+        for node_name in node_list:
+            route_domain = split_ip_with_route_domain(node_name)[1]
+            if route_domain is None:
+                break
+        else:
+            return
+
+        existing_iapps = self._bigip.get_app_svcs()
+        existing_virtuals = self._bigip.get_virtuals()
+        existing_pools = self._bigip.get_pools()
+
+        delete_iapps = self._get_resource_tasks(existing_iapps, {})[-1]
+        delete_virtuals = self._get_resource_tasks(existing_virtuals, {})[-1]
+        delete_pools = self._get_resource_tasks(existing_pools, {})[-1]
+        delete_nodes = self._get_resource_tasks(existing_nodes, {})[-1]
+
+        delete_tasks = (delete_iapps + delete_virtuals
+                        + delete_pools + delete_nodes)
+        taskq_len = len(delete_tasks)
+
+        finished = False
+        LOGGER.debug("Removing legacy resources...")
+        while not finished:
+            LOGGER.debug("Legacy cleanup service task queue length: %d",
+                         taskq_len)
+
+            # Must remove all resources that depend on nodes (vs, pools, ???)
+            delete_tasks = self._delete_resources(delete_tasks)
+
+            tasks_remaining = len(delete_tasks)
+
+            # Did the task queue shrink?
+            if tasks_remaining >= taskq_len or tasks_remaining == 0:
+                # No, we have stopped making progress.
+                finished = True
+
+            # Reset the taskq length.
+            taskq_len = tasks_remaining
+
+    def _post_deploy(self, desired_config, default_route_domain):
         """Perform post-deployment service tasks/cleanup.
 
         Remove superfluous resources that could not be inferred from the
@@ -184,7 +251,7 @@ class ServiceConfigDeployer(object):
         # Delete/update nodes (no creation)
         LOGGER.debug("Post-process nodes.")
         existing = self._bigip.get_nodes()
-        desired = self._desired_nodes()
+        desired = self._desired_nodes(default_route_domain)
         (update_nodes, delete_nodes) = \
             self._get_resource_tasks(existing, desired)[1:3]
         self._update_resources(update_nodes)
@@ -210,7 +277,8 @@ class ServiceConfigDeployer(object):
 
         self._update_resources(update_vaddrs)
 
-    def deploy(self, desired_config):  # pylint: disable=too-many-locals
+    def deploy(  # pylint: disable=too-many-locals,too-many-statements
+            self, desired_config, default_route_domain):
         """Deploy the managed partition with the desired config.
 
         :param desired_config: A dictionary with the configuration
@@ -218,6 +286,13 @@ class ServiceConfigDeployer(object):
 
         :returns: The number of tasks that could not be completed.
         """
+
+        # Remove legacy resources (pre RD-named resources) before deploying
+        # new configuration
+        if ServiceConfigDeployer.first_pass:
+            ServiceConfigDeployer.first_pass = False
+            self._pre_deploy_legacy_cleanup()
+
         self._bigip.refresh()
 
         # Get the list of virtual address tasks
@@ -229,17 +304,17 @@ class ServiceConfigDeployer(object):
 
         # Get the list of virtual server tasks
         LOGGER.debug("Getting virtual server tasks...")
-        existing = self._bigip.get_virtuals()
+        existing_virtuals = self._bigip.get_virtuals()
         desired = desired_config.get('virtuals', dict())
         (create_virtuals, update_virtuals, delete_virtuals) = (
-            self._get_resource_tasks(existing, desired))
+            self._get_resource_tasks(existing_virtuals, desired))
 
         # Get the list of pool tasks
         LOGGER.debug("Getting pool tasks...")
-        existing = self._bigip.get_pools()
+        existing_pools = self._bigip.get_pools()
         desired = desired_config.get('pools', dict())
         (create_pools, update_pools, delete_pools) = (
-            self._get_resource_tasks(existing, desired))
+            self._get_resource_tasks(existing_pools, desired))
 
         # Get the list of irule tasks
         LOGGER.debug("Getting iRule tasks...")
@@ -265,10 +340,10 @@ class ServiceConfigDeployer(object):
 
         # Get the list of iapp tasks
         LOGGER.debug("Getting iApp tasks...")
-        existing = self._bigip.get_app_svcs()
+        existing_iapps = self._bigip.get_app_svcs()
         desired = desired_config.get('iapps', dict())
         (create_iapps, update_iapps, delete_iapps) = (
-            self._get_resource_tasks(existing, desired))
+            self._get_resource_tasks(existing_iapps, desired))
 
         # Get the list of monitor tasks
         LOGGER.debug("Getting monitor tasks...")
@@ -319,7 +394,7 @@ class ServiceConfigDeployer(object):
             # Reset the taskq length.
             taskq_len = tasks_remaining
 
-        self._post_deploy(desired_config)
+        self._post_deploy(desired_config, default_route_domain)
 
         return taskq_len
 
@@ -341,6 +416,7 @@ class ServiceManager(object):
             API schema.
         """
         self._partition = partition
+        self._bigip = bigip_proxy
         self._config_validator = ServiceConfigValidator(schema)
         self._service_deployer = ServiceConfigDeployer(bigip_proxy)
         self._config_reader = ServiceConfigReader(self._partition)
@@ -351,6 +427,7 @@ class ServiceManager(object):
 
     def apply_config(self, service_config):
         """Apply the desired service configuration.
+
         Args:
             service_config: The desired configuration state of the mananged
             partition.
@@ -369,11 +446,16 @@ class ServiceManager(object):
         # Validate the service configuration.
         self._config_validator.validate(service_config)
 
+        # Determine the default route domain for the partition
+        default_route_domain = self._bigip.get_default_route_domain()
+
         # Read in the configuration
-        desired_config = self._config_reader.read_config(service_config)
+        desired_config = self._config_reader.read_config(
+            service_config, default_route_domain)
 
         # Deploy the service desired configuratio.
-        retval = self._service_deployer.deploy(desired_config)
+        retval = self._service_deployer.deploy(
+            desired_config, default_route_domain)
 
         LOGGER.debug(
             "apply_config took %.5f seconds.", (time() - start_time))

--- a/f5_cccl/service/test/test_config_reader.py
+++ b/f5_cccl/service/test/test_config_reader.py
@@ -46,7 +46,7 @@ class TestServiceConfigReader:
 
     def test_get_config(self):
         reader = ServiceConfigReader(self.partition)
-        config = reader.read_config(self.service)
+        config = reader.read_config(self.service, 0)
 
         assert len(config.get('virtuals')) == 1
         assert len(config.get('pools')) == 1
@@ -62,4 +62,4 @@ class TestServiceConfigReader:
         with patch.object(ApiVirtualServer, '__init__', side_effect=ValueError("test exception")):
             reader = ServiceConfigReader(self.partition)
             with pytest.raises(F5CcclConfigurationReadError) as e:
-                reader.read_config(self.service)
+                reader.read_config(self.service, 0)

--- a/f5_cccl/service/test/test_service_manager.py
+++ b/f5_cccl/service/test/test_service_manager.py
@@ -64,7 +64,9 @@ class TestServiceConfigDeployer:
             self.service = json.loads(fp.read())
 
         config_reader = ServiceConfigReader(self.partition)
-        self.desired_config = config_reader.read_config(self.service)
+        self.default_route_domain = self.bigip.get_default_route_domain()
+        self.desired_config = config_reader.read_config(
+            self.service, self.default_route_domain)
 
     def get_objects(self, objs, obj_type):
         """Extract objects of obj_type from the list."""
@@ -110,7 +112,8 @@ class TestServiceConfigDeployer:
     def test_deploy(self):
         deployer = ServiceConfigDeployer(
             self.bigip)
-        tasks_remaining = deployer.deploy(self.desired_config)
+        tasks_remaining = deployer.deploy(
+            self.desired_config, self.default_route_domain)
         assert 0 == tasks_remaining
 
     def test_app_services(self, service_manager):

--- a/f5_cccl/test/conftest.py
+++ b/f5_cccl/test/conftest.py
@@ -314,6 +314,49 @@ class VxLANTunnel():
             self.records = kwargs['records']
 
 
+class Partition():
+    """A mock BIG-IP Partition."""
+
+    def __init__(self, name, **kwargs):
+        """Initialize the object."""
+        self.name = name
+        if kwargs.get('default-route-domain') is not None:
+            self.defaultRouteDomain = kwargs.get('default-route-domain')
+        else:
+            self.defaultRouteDomain = 0
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+        self.raw = self.__dict__
+
+    def modify(self, **kwargs):
+        """Placeholder: This will be mocked."""
+        pass
+
+    def create(self, name=None, **kwargs):
+        """Create the partition object."""
+        pass
+
+    def delete(self):
+        """Delete the partition object."""
+        pass
+
+    def load(self, name=None):
+        """Load the partition object."""
+        return Partition(name)
+
+
+class MockPartitions():
+    """A mock Auth partitions object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.partition = Partition('test')
+
+    def get_collection(self):
+        """Get collection of partitions."""
+        pass
+
+
 class MockService():
     """A mock Services service object."""
 
@@ -696,6 +739,12 @@ class MockDataGroup():
         """Initialize the object."""
         self.internals = MockDataGroupInternals()
 
+class MockAuth():
+    """A mock BIG-IP auth object."""
+
+    def __init__(self):
+        """Initialize the object."""
+        self.partitions = MockPartitions()
 
 class MockLtm():
     """A mock BIG-IP ltm object."""
@@ -714,6 +763,7 @@ class MockLtm():
 class MockTm():
     def __init__(self):
         self.ltm = MockLtm()
+        self.auth = MockAuth()
         self.sys = MockSys()
 
 

--- a/f5_cccl/test/test_bigip.py
+++ b/f5_cccl/test/test_bigip.py
@@ -36,7 +36,7 @@ def test_bigip_refresh(bigip_proxy):
         if i['partition'] == 'test'
     ]
     test_nodes = [
-        Node(**n) for n in big_ip.bigip_data['nodes']
+        Node(default_route_domain=0, **n) for n in big_ip.bigip_data['nodes']
         if n['partition'] == 'test'
     ]
 

--- a/f5_cccl/utils/route_domain.py
+++ b/f5_cccl/utils/route_domain.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Helper functions for supporting route domains"""
+
+import re
+from requests.utils import quote as urlquote
+from requests.utils import unquote as urlunquote
+
+
+# Pattern: <ipaddr>%<route_domain>
+ip_rd_re = re.compile(r'^([^%]*)%(\d+)$')
+
+# Pattern: <partition/folder_paths>/<ipaddr>%<route_domain>[:|.]<port>
+path_ip_rd_port_re = re.compile(r'^(.+)/(.+)%(\d+)[:|\.](.+)$')
+
+
+def combine_ip_and_route_domain(ip, route_domain):
+    u"""Return address that includes IP and route domain
+
+    Input ip format must be of the form:
+        <ipv4_or_ipv6>
+    """
+    address = "{}%{}".format(ip, route_domain)
+    return address
+
+
+def split_ip_with_route_domain(address):
+    u"""Return ip and route-domain parts of address
+
+    Input ip format must be of the form:
+        <ip_v4_or_v6_addr>[%<route_domain_id>]
+    """
+    match = ip_rd_re.match(address)
+    if match:
+        ip = match.group(1)
+        route_domain = int(match.group(2))
+    else:
+        ip = address
+        route_domain = None
+
+    return ip, route_domain
+
+
+def normalize_address_with_route_domain(address, default_route_domain):
+    u"""Return address with the route domain
+
+    Return components of address, using the default route domain
+    for the partition if one is not already specified.
+
+    Input address is of the form:
+        <ip_v4_or_v6_addr>[%<route_domain_id>]
+    """
+    match = ip_rd_re.match(address)
+    if match:
+        ip = match.group(1)
+        route_domain = int(match.group(2))
+    else:
+        route_domain = default_route_domain
+        ip = address
+        address = combine_ip_and_route_domain(ip, route_domain)
+
+    return address, ip, route_domain
+
+
+def encoded_normalize_address_with_route_domain(address,
+                                                default_route_domain,
+                                                inputUrlEncoded,
+                                                outputUrlEncoded):
+    """URL Encoded-aware version of normalize_address_with_route_domain"""
+    if inputUrlEncoded:
+        address = urlunquote(address)
+
+    address = normalize_address_with_route_domain(address,
+                                                  default_route_domain)[0]
+
+    if outputUrlEncoded:
+        address = urlquote(address)
+    return address

--- a/f5_cccl/utils/test/test_route_domain.py
+++ b/f5_cccl/utils/test/test_route_domain.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from requests.utils import quote as urlquote
+
+from f5_cccl.utils.route_domain \
+    import combine_ip_and_route_domain
+from f5_cccl.utils.route_domain \
+    import encoded_normalize_address_with_route_domain
+from f5_cccl.utils.route_domain \
+        import normalize_address_with_route_domain
+from f5_cccl.utils.route_domain \
+        import split_ip_with_route_domain
+
+
+def test_combine_ip_and_route_domain():
+    """Test proper behavior of combine_ip_and_route_domain."""
+
+    tests = [
+        ["1.2.3.4", 12, "1.2.3.4%12"],
+        ["64:ff9b::", 13, "64:ff9b::%13"]
+    ]
+    for test in tests:
+        result = combine_ip_and_route_domain(test[0], test[1])
+        assert result == test[2]
+
+    # def combine_ip_and_route_domain(ip, route_domain):
+    # u"""Return address that includes IP and route domain
+
+    # Input ip format must be of the form:
+    #     <ipv4_or_ipv6>
+    # """
+    # address = "{}%{}".format(ip, route_domain)
+    # return address
+
+
+def test_split_ip_with_route_domain():
+    """Test proper behavior of split_ip_with_route_domain."""
+
+    tests = [
+        ["1.2.3.4%1", "1.2.3.4", 1],
+        ["1.2.3.4", "1.2.3.4", None],
+        ["64:ff9b::%2", "64:ff9b::", 2],
+        ["64:ff9b::", "64:ff9b::", None]
+    ]
+    for test in tests:
+        results = split_ip_with_route_domain(test[0])
+        assert results[0] == test[1]
+        assert results[1] == test[2]
+
+def test_normalize_address_with_route_domain():
+    """Test proper behavior of normalize_address_with_route_domain."""
+
+    # If route domain is not specified, add the default
+    tests = [
+        ["1.2.3.4%1", 2, "1.2.3.4%1", "1.2.3.4", 1],
+        ["1.2.3.4", 2, "1.2.3.4%2", "1.2.3.4", 2],
+        ["64:ff9b::%1", 2, "64:ff9b::%1", "64:ff9b::", 1],
+        ["64:ff9b::", 2, "64:ff9b::%2", "64:ff9b::", 2]
+    ]
+    for test in tests:
+        results = normalize_address_with_route_domain(test[0], test[1])
+        assert results[0] == test[2]
+        assert results[1] == test[3]
+        assert results[2] == test[4]
+
+def test_encoded_normalize_address_with_route_domain():
+    """Test proper behavior of encoded_normalize_address_with_route_domain."""
+
+    # test wrapper for test_normalize_address_with_route_domain but with
+    # address input/output being either url encoded or url unencoded
+    tests = [
+        ["1.2.3.4%1", 2, False, False, "1.2.3.4%1"],
+        ["1.2.3.4%1", 2, False, True, urlquote("1.2.3.4%1")],
+        [urlquote("1.2.3.4%1"), 2, True, False, "1.2.3.4%1"],
+        [urlquote("1.2.3.4%1"), 2, True, True, urlquote("1.2.3.4%1")],
+
+        ["64:ff9b::", 2, False, False, "64:ff9b::%2"],
+        ["64:ff9b::", 2, False, True, urlquote("64:ff9b::%2")],
+        [urlquote("64:ff9b::"), 2, True, False, "64:ff9b::%2"],
+        [urlquote("64:ff9b::"), 2, True, True, urlquote("64:ff9b::%2")]
+    ]
+
+    for test in tests:
+        result = encoded_normalize_address_with_route_domain(
+            test[0], test[1], test[2], test[3])
+        assert result == test[4]

--- a/test/f5_cccl/perf/test_perf.py
+++ b/test/f5_cccl/perf/test_perf.py
@@ -65,7 +65,7 @@ def _make_svc_config(partition, num_virtuals=0, num_members=0):
         "monitors": ["/Common/http"]
     },
     base_member ={
-        "address": "172.16.0.100", "port": 8080, "routeDomain": {"id": 0}
+        "address": "172.16.0.100%0", "port": 8080
     }
 
 


### PR DESCRIPTION
    The pool members now include the route domain whether the user
    specified it or not (if not, the default route domain is used).
    This allows the node names that get created to include the route
    domain ID.  By doing this, we won't run into conflicts when the
    partition's default route domain is changed.  The fix also
    solves issues with multiple route domains on pool members.
    
    There are the following major changes in this commit:
      1. Removed the separate definition for route domains and made it
         be part of the address to mimic BigIP (this would be a breaking
         change, but none of the controller make use of it at this time).
      2. Force route domain to be part of pool addresses when we create
         them (on retrieval from Big-IP add it if missing).
      3. To smooth transition from previous version of cccl, added a pre-configure
         check to see if node names are using the old format.  If so, the resources
         are removed before applying the new config (this check only occurs at startup).
    
    One minor/cosmetic change:
      1. Created the IcrNode class to be consistent with all other Icr
         resources (instead of using the base Node class directly).
      2. Prevent pool members from being named. Names are auto-generated and include the 
         route domain.
