### PR TITLE
Update config reader to accept partition in obj

### DIFF
--- a/f5_cccl/schemas/tests/service.json
+++ b/f5_cccl/schemas/tests/service.json
@@ -181,7 +181,8 @@
   "iRules": [
     {
       "name": "https_redirect",
-      "apiAnonymous": "when HTTP_REQUEST {HTTP::redirect https://[getfield [HTTP::host] ':' 1][HTTP::uri]}"
+      "apiAnonymous": "when HTTP_REQUEST {HTTP::redirect https://[getfield [HTTP::host] ':' 1][HTTP::uri]}",
+      "partition": "test"
     }
   ],
   "internalDataGroups": [

--- a/f5_cccl/service/config_reader.py
+++ b/f5_cccl/service/config_reader.py
@@ -60,9 +60,12 @@ class ServiceConfigReader(object):
         """
         config_resource = None
         try:
-            config_resource = resource_type(
-                partition=self._partition,
-                **obj)
+            if 'partition' not in obj:
+                obj['partition'] = self._partition
+            else:
+                if obj['partition'] != self._partition:
+                    raise ValueError("Partition names do not match")
+            config_resource = resource_type(**obj)
         except (ValueError, TypeError) as error:
             msg_format = \
                 "Failed to create resource {}, {} from config: error({})"

--- a/f5_cccl/service/test/test_config_reader.py
+++ b/f5_cccl/service/test/test_config_reader.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import copy
 import json
 import pytest
 
@@ -31,7 +32,7 @@ from mock import patch
 class TestServiceConfigReader:
 
     def setup(self):
-        self.partition = "Test"
+        self.partition = "test"
 
         svcfile = 'f5_cccl/schemas/tests/service.json'
         with open(svcfile, 'r') as fp:
@@ -56,6 +57,15 @@ class TestServiceConfigReader:
         assert len(config.get('tcp_monitors')) == 1
         assert len(config.get('l7policies')) == 1
         assert len(config.get('iapps')) == 1
+
+    def test_get_config_bad_partition(self):
+        reader = ServiceConfigReader(self.partition)
+        # Copy the current config and update the partition to a wrong value
+        config = copy.deepcopy(self.service)
+        config['iRules'][0]['partition'] = 'wrong'
+        with pytest.raises(F5CcclConfigurationReadError) as e:
+            reader.read_config(config)
+        assert 'Partition names do not match' in e.value.msg
 
     def test_create_config_item_exception(self):
 


### PR DESCRIPTION
Problem:
If an object is passed in containing a partition config_reader will
return a duplicate key error as the partition is being passed in twice
to the ltm object class

Solution:
Update config_reader to check for a partition on the obj and if not
there to add it then stop passing partition as a keyword to the ltm
object class
Added test to verify check is working properly and error is raised if
partition does not match

Fixes #175 