### PR TITLE
Remove partition from iRule and DataGroup

### DIFF
--- a/f5_cccl/schemas/cccl-api-schema.yml
+++ b/f5_cccl/schemas/cccl-api-schema.yml
@@ -798,8 +798,6 @@ definitions:
     properties:
       name:
         type: "string"
-      partition:
-        type: "string"
       apiAnonymous:
         type: "string"
     required:
@@ -810,8 +808,6 @@ definitions:
     type: "object"
     properties:
       name:
-        type: "string"
-      partition:
         type: "string"
       type:
         type: "string"


### PR DESCRIPTION
Problem:
Schema shows a partition for these two objects and if a partition is
passed through cccl will throw a duplicate key error

Solution:
Remove this from the schema as the partition is known based on the
config coming into cccl