### PR TITLE
[WIP] Added route domain support for iapp pool members

### DIFF
--- a/f5_cccl/resource/ltm/app_service.py
+++ b/f5_cccl/resource/ltm/app_service.py
@@ -19,6 +19,7 @@
 import logging
 
 from f5_cccl.resource import Resource
+from f5_cccl.utils.route_domain import normalize_address_with_route_domain
 
 
 LOGGER = logging.getLogger(__name__)
@@ -111,7 +112,8 @@ class IcrApplicationService(ApplicationService):
 
 class ApiApplicationService(ApplicationService):
     """Parse the CCCL input to create the canonical Application Service."""
-    def __init__(self, name, partition, **properties):
+    def __init__(self, name, partition, default_route_domain, **properties):
+        self._default_route_domain = default_route_domain
         super(ApiApplicationService, self).__init__(name,
                                                     partition,
                                                     **properties)
@@ -155,7 +157,9 @@ class ApiApplicationService(ApplicationService):
                         row.append(col['value'])
                     elif 'kind' in col:
                         if col['kind'] == 'IPAddress':
-                            row.append(str(node['address']))
+                            address = normalize_address_with_route_domain(
+                                node['address'], self._default_route_domain)[0]
+                            row.append(address)
                         elif col['kind'] == 'Port':
                             row.append(str(node['port']))
 

--- a/f5_cccl/resource/ltm/test/test_app_service.py
+++ b/f5_cccl/resource/ltm/test/test_app_service.py
@@ -26,6 +26,7 @@ cfg_test = {
   "name": "MyAppService",
   "template": "/Common/f5.http",
   "partition": "test",
+  "default_route_domain": 0,
   "options": {"description": "This is a test iApp"},
   "poolMemberTable": {
     "name": "pool__members",
@@ -72,6 +73,7 @@ cfg_test2 = {
   "name": "appsvc",
   "template": "/Common/appsvcs_integration_v2.0.002",
   "partition": "test",
+  "default_route_domain": 22,
   "options": {"description": "This is a test iApp"},
   "poolMemberTable": {
     "name": "pool__Members",
@@ -140,11 +142,11 @@ cfg_test_expected = {
   "tables": [{
     "name": "pool__members",
     "columnNames": ["addr", "port", "connection_limit"],
-    "rows": [{"row": ["10.2.3.4", "30001", "0"]},
-             {"row": ["10.2.3.4", "30002", "0"]},
-             {"row": ["10.2.3.4", "30003", "0"]},
-             {"row": ["10.2.3.4", "30004", "0"]},
-             {"row": ["10.2.3.4", "30005", "0"]}]
+    "rows": [{"row": ["10.2.3.4%0", "30001", "0"]},
+             {"row": ["10.2.3.4%0", "30002", "0"]},
+             {"row": ["10.2.3.4%0", "30003", "0"]},
+             {"row": ["10.2.3.4%0", "30004", "0"]},
+             {"row": ["10.2.3.4%0", "30005", "0"]}]
     }
   ],
   "variables": [
@@ -182,11 +184,11 @@ cfg_test2_expected = {
     "name": "pool__Members",
     "columnNames": ["Index", "IPAddress", "Port", "ConnectionLimit", "Ratio",
                     "PriorityGroup", "State"],
-    "rows": [{"row": ["0", "10.2.3.5", "30001", "1000", "1", "0", "enabled"]},
-             {"row": ["0", "10.2.3.5", "30002", "1000", "1", "0", "enabled"]},
-             {"row": ["0", "10.2.3.5", "30003", "1000", "1", "0", "enabled"]},
-             {"row": ["0", "10.2.3.5", "30004", "1000", "1", "0", "enabled"]},
-             {"row": ["0", "10.2.3.5", "30005", "1000", "1", "0", "enabled"]}]
+    "rows": [{"row": ["0", "10.2.3.5%22", "30001", "1000", "1", "0", "enabled"]},
+             {"row": ["0", "10.2.3.5%22", "30002", "1000", "1", "0", "enabled"]},
+             {"row": ["0", "10.2.3.5%22", "30003", "1000", "1", "0", "enabled"]},
+             {"row": ["0", "10.2.3.5%22", "30004", "1000", "1", "0", "enabled"]},
+             {"row": ["0", "10.2.3.5%22", "30005", "1000", "1", "0", "enabled"]}]
   },
   {
     "name": "l7policy__rulesMatch",

--- a/f5_cccl/service/config_reader.py
+++ b/f5_cccl/service/config_reader.py
@@ -151,7 +151,8 @@ class ServiceConfigReader(object):
 
         iapps = service_config.get('iapps', list())
         config_dict['iapps'] = {
-            i['name']: self._create_config_item(ApiApplicationService, i)
+            i['name']: self._create_config_item(ApiApplicationService, i,
+                                                default_route_domain)
             for i in iapps
         }
 


### PR DESCRIPTION
Force the pool members to always specify a route domain so that
node creation and pool member names are consistent with virtual
server definitions and allows the partition default route domain
to change on the fly.

==> THIS IS ONLY FOR REVIEW AND SHOULD NOT BE ACCEPTED <==