### PR TITLE
Issue #184: Conflict with App Svcs iApp and OpenShift routes

### DIFF
--- a/f5_cccl/bigip.py
+++ b/f5_cccl/bigip.py
@@ -274,7 +274,8 @@ class BigIPProxy(object):
         #  Delete non-legacy policies
         policies = [
             p for p in all_policies
-            if self._policy_status_check(p, virtuals)
+            if self._manageable_resource(p)
+            and self._policy_status_check(p, virtuals)
         ]
 
         #  Refresh the virtuals cache.


### PR DESCRIPTION
We delete published policies and remove them from virtual servers,
but don't do this if the policy belongs to an App Service.