### PR TITLE
Allow setting caFile in server SSL profiles

### DIFF
--- a/f5_cccl/utils/profile.py
+++ b/f5_cccl/utils/profile.py
@@ -92,11 +92,17 @@ def create_server_ssl_profile(mgmt, partition, profile):
         # Unable to install cert
         return incomplete
 
+    caFile = profile.get('caFile', '')
+    if caFile == 'self':
+        # Do not create a SSL profile, just install the certificate.
+        return 0
+
     try:
         # create ssl-server profile
         serverName = profile.get('serverName', None)
         sniDefault = profile.get('sniDefault', False)
         peerCertMode = profile.get('peerCertMode', 'ignore')
+        caFile = profile.get('caFile', '')
         kwargs = {}
         if cert != "":
             kwargs = {'chain': cert_name}
@@ -106,6 +112,7 @@ def create_server_ssl_profile(mgmt, partition, profile):
                                   serverName=serverName,
                                   sniDefault=sniDefault,
                                   peerCertMode=peerCertMode,
+                                  caFile=caFile,
                                   **kwargs)
     except Exception as err:  # pylint: disable=broad-except
         incomplete += 1

--- a/f5_cccl/utils/profile.py
+++ b/f5_cccl/utils/profile.py
@@ -102,7 +102,6 @@ def create_server_ssl_profile(mgmt, partition, profile):
         serverName = profile.get('serverName', None)
         sniDefault = profile.get('sniDefault', False)
         peerCertMode = profile.get('peerCertMode', 'ignore')
-        caFile = profile.get('caFile', '')
         kwargs = {}
         if cert != "":
             kwargs = {'chain': cert_name}


### PR DESCRIPTION
Problem:
When peerCert is set to "require" in the server SSL profile it uses the
caFile member (Trusted Certificate Authorities in the Server
Authentication section as viewed in the UI) to validate the server
certificate, not the Chain member in Configuration section.

Solution:
Added knowledge of the caFile member in SSL profiles. The default value
of caFile is an empty string which is consistent with previous
behavior, but it can also be the path to the CA certificate on the
BIG-IP (/Common/some-ca.crt) or 'self' which indicates that the profile
contains the CA certificate itself and that a SSL profile should NOT be
configured, just install the certificate.

affects-branches: master