### PR TITLE
Set "source" default for Virtual resource

### DIFF
--- a/f5_cccl/resource/ltm/virtual.py
+++ b/f5_cccl/resource/ltm/virtual.py
@@ -127,12 +127,15 @@ class ApiVirtualServer(VirtualServer):
         else:
             vlansDisabled = None
 
+        source = properties.pop('source', '0.0.0.0/0')
+
         super(ApiVirtualServer, self).__init__(name,
                                                partition,
                                                enabled=enabled,
                                                disabled=disabled,
                                                vlansEnabled=vlansEnabled,
                                                vlansDisabled=vlansDisabled,
+                                               source=source,
                                                **properties)
 
 


### PR DESCRIPTION
Problem: The CF controller uses the "source" field on virtuals, but
the k8s controller does not. This field was processed as a default field,
but since the k8s controller did not populate the field, there were constant
virtual server updates due to mismatching fields.

Solution: Set a source default if one is not provided, preventing any unnecessary
updates if the field is not provided by a controller.