### PR TITLE
Handle route domain for virtual source addr

### DIFF
--- a/f5_cccl/resource/ltm/virtual.py
+++ b/f5_cccl/resource/ltm/virtual.py
@@ -127,7 +127,20 @@ class ApiVirtualServer(VirtualServer):
         else:
             vlansDisabled = None
 
+        destination = properties.get('destination', None)
+        rd = None
+        if '%' in destination:
+            try:
+                rd = re.findall(r"%(\d+)(:|.)", destination)[0][0]
+            except IndexError:
+                LOGGER.error(
+                    "Could not extract route domain from destination '%s'",
+                    destination)
+
         source = properties.pop('source', '0.0.0.0/0')
+        if rd and '%' not in source:
+            idx = source.index('/')
+            source = source[:idx] + '%{}'.format(rd) + source[idx:]
 
         super(ApiVirtualServer, self).__init__(name,
                                                partition,


### PR DESCRIPTION
Problem: When adding a default source addr to a virtual (0.0.0.0/0), route domains were not being
considered, which resulted in mismatched source and destination route domains.

Solution: Add the destination's route domain to the default source addr to ensure consistency.