### PR TITLE
Strip leading/trailing whitespace from iRule

### DIFF
--- a/f5_cccl/resource/ltm/irule.py
+++ b/f5_cccl/resource/ltm/irule.py
@@ -42,6 +42,9 @@ class IRule(Resource):
             'apiAnonymous',
             self.properties.get('apiAnonymous')
         )
+        # Strip any leading/trailing whitespace
+        if self._data['apiAnonymous'] is not None:
+            self._data['apiAnonymous'] = self._data['apiAnonymous'].strip()
 
     def __eq__(self, other):
         """Check the equality of the two objects.

--- a/f5_cccl/resource/ltm/test/test_irule.py
+++ b/f5_cccl/resource/ltm/test/test_irule.py
@@ -50,7 +50,7 @@ def test_create_irule():
 
     # verify all cfg items
     for k,v in cfg_test.items():
-        assert irule.data[k] == v
+        assert irule.data[k] == v.strip()
 
 
 def test_hash():
@@ -131,3 +131,22 @@ def test_uri_path(bigip):
     assert irule
 
     assert irule._uri_path(bigip) == bigip.tm.ltm.rules.rule
+
+
+def test_whitespace():
+    """Verify that leading/trailing whitespace is removed from iRule."""
+    whitespace = '\n\t   '
+    ssl_redirect_irule_ws = whitespace + ssl_redirect_irule_1 + whitespace
+
+    cfg_ws = {
+        'name': 'ssl_redirect',
+        'partition': 'my_partition',
+        'apiAnonymous': ssl_redirect_irule_ws
+    }
+
+    irule = IRule(
+        **cfg_ws
+    )
+
+    assert irule
+    assert irule.data['apiAnonymous'] == ssl_redirect_irule_1.strip()


### PR DESCRIPTION
Problem:
Leading and trailing whitespace will be stripped from the
apiAnonymous field in the iRule by the BIG-IP, causing equality
checks to fail and resulting in perpetual updates to the iRule.

Solution:
Strip the leading/trailing whitespace from apiAnonymous when
creating the iRule.