### PR TITLE
Enforce relationship between health monitor interval and timeout

### DIFF
--- a/f5_cccl/resource/ltm/monitor/http_monitor.py
+++ b/f5_cccl/resource/ltm/monitor/http_monitor.py
@@ -60,4 +60,10 @@ class ApiHTTPMonitor(HTTPMonitor):
 
 class IcrHTTPMonitor(HTTPMonitor):
     """Create the canonical HTTP monitor from iControl REST response."""
-    pass
+    def __init__(self, name, partition, **kwargs):
+        try:
+            super(IcrHTTPMonitor, self).__init__(name, partition, **kwargs)
+        except ValueError:
+            # Need to allow for misconfigured legacy monitors from BIG-IP,
+            # so let this through
+            pass

--- a/f5_cccl/resource/ltm/monitor/https_monitor.py
+++ b/f5_cccl/resource/ltm/monitor/https_monitor.py
@@ -60,4 +60,10 @@ class ApiHTTPSMonitor(HTTPSMonitor):
 
 class IcrHTTPSMonitor(HTTPSMonitor):
     """Create the canonical HTTPS monitor from iControl REST response."""
-    pass
+    def __init__(self, name, partition, **kwargs):
+        try:
+            super(IcrHTTPSMonitor, self).__init__(name, partition, **kwargs)
+        except ValueError:
+            # Need to allow for misconfigured legacy monitors from BIG-IP,
+            # so let this through
+            pass

--- a/f5_cccl/resource/ltm/monitor/icmp_monitor.py
+++ b/f5_cccl/resource/ltm/monitor/icmp_monitor.py
@@ -50,4 +50,10 @@ class ApiICMPMonitor(ICMPMonitor):
 
 class IcrICMPMonitor(ICMPMonitor):
     """Create the canonical ICMP monitor from the iControl REST response."""
-    pass
+    def __init__(self, name, partition, **kwargs):
+        try:
+            super(IcrICMPMonitor, self).__init__(name, partition, **kwargs)
+        except ValueError:
+            # Need to allow for misconfigured legacy monitors from BIG-IP,
+            # so let this through
+            pass

--- a/f5_cccl/resource/ltm/monitor/monitor.py
+++ b/f5_cccl/resource/ltm/monitor/monitor.py
@@ -49,6 +49,13 @@ class Monitor(Resource):
         for key, value in self.properties.items():
             self._data[key] = kwargs.get(key, value)
 
+        # Check for invalid interval/timeout values
+        if self._data['interval'] >= self._data['timeout']:
+            raise ValueError(
+                "Health Monitor interval ({}) must be less than "
+                "timeout ({})".format(self._data['interval'],
+                                      self._data['timeout']))
+
     def __str__(self):
         return("Monitor(partition: {}, name: {}, type: {})".format(
             self._data['partition'], self._data['name'], type(self)))

--- a/f5_cccl/resource/ltm/monitor/tcp_monitor.py
+++ b/f5_cccl/resource/ltm/monitor/tcp_monitor.py
@@ -58,4 +58,10 @@ class ApiTCPMonitor(TCPMonitor):
 
 class IcrTCPMonitor(TCPMonitor):
     """Create the canonical TCP monitor from API input."""
-    pass
+    def __init__(self, name, partition, **kwargs):
+        try:
+            super(IcrTCPMonitor, self).__init__(name, partition, **kwargs)
+        except ValueError:
+            # Need to allow for misconfigured legacy monitors from BIG-IP,
+            # so let this through
+            pass

--- a/f5_cccl/resource/ltm/monitor/test/test_http_monitor.py
+++ b/f5_cccl/resource/ltm/monitor/test/test_http_monitor.py
@@ -81,3 +81,15 @@ def test_create_api_monitor(http_config):
     monitor = target.ApiHTTPMonitor(**http_config)
 
     assert isinstance(monitor, target.HTTPMonitor)
+
+
+def test_create_monitors_invalid(http_config):
+    # Set interval to be larger than timeout,
+    # ICR Monitor will be created, API Monitor will not
+    http_config['interval'] = 30
+    monitor = target.IcrHTTPMonitor(**http_config)
+
+    assert isinstance(monitor, target.IcrHTTPMonitor)
+
+    with pytest.raises(ValueError):
+        monitor = target.ApiHTTPMonitor(**http_config)

--- a/f5_cccl/resource/ltm/monitor/test/test_https_monitor.py
+++ b/f5_cccl/resource/ltm/monitor/test/test_https_monitor.py
@@ -83,3 +83,15 @@ def test_create_api_monitor(https_config):
     monitor = target.ApiHTTPSMonitor(**https_config)
 
     assert isinstance(monitor, target.HTTPSMonitor)
+
+
+def test_create_monitors_invalid(https_config):
+    # Set interval to be larger than timeout,
+    # ICR Monitor will be created, API Monitor will not
+    https_config['interval'] = 30
+    monitor = target.IcrHTTPSMonitor(**https_config)
+
+    assert isinstance(monitor, target.IcrHTTPSMonitor)
+
+    with pytest.raises(ValueError):
+        monitor = target.ApiHTTPSMonitor(**https_config)

--- a/f5_cccl/resource/ltm/monitor/test/test_icmp_monitor.py
+++ b/f5_cccl/resource/ltm/monitor/test/test_icmp_monitor.py
@@ -77,3 +77,15 @@ def test_create_api_monitor(icmp_config):
     monitor = target.ApiICMPMonitor(**icmp_config)
 
     assert isinstance(monitor, target.ICMPMonitor)
+
+
+def test_create_monitors_invalid(icmp_config):
+    # Set interval to be larger than timeout,
+    # ICR Monitor will be created, API Monitor will not
+    icmp_config['interval'] = 30
+    monitor = target.IcrICMPMonitor(**icmp_config)
+
+    assert isinstance(monitor, target.IcrICMPMonitor)
+
+    with pytest.raises(ValueError):
+        monitor = target.ApiICMPMonitor(**icmp_config)

--- a/f5_cccl/resource/ltm/monitor/test/test_monitor.py
+++ b/f5_cccl/resource/ltm/monitor/test/test_monitor.py
@@ -112,3 +112,12 @@ def test_uri_path():
                              partition=partition)
     with pytest.raises(NotImplementedError):
         monitor._uri_path(MagicMock())
+
+
+def test_invalid_interval_and_timeout():
+    monitors = list(api_monitors_cfg)
+    for mon in monitors:
+        mon['interval'] = 10
+        mon['timeout'] = 5
+        with pytest.raises(ValueError):
+            monitor = target.Monitor(partition=partition, **mon)

--- a/f5_cccl/resource/ltm/monitor/test/test_tcp_monitor.py
+++ b/f5_cccl/resource/ltm/monitor/test/test_tcp_monitor.py
@@ -82,3 +82,15 @@ def test_create_api_monitor(tcp_config):
     monitor = target.ApiTCPMonitor(**tcp_config)
 
     assert isinstance(monitor, target.TCPMonitor)
+
+
+def test_create_monitors_invalid(tcp_config):
+    # Set interval to be larger than timeout,
+    # ICR Monitor will be created, API Monitor will not
+    tcp_config['interval'] = 30
+    monitor = target.IcrTCPMonitor(**tcp_config)
+
+    assert isinstance(monitor, target.IcrTCPMonitor)
+
+    with pytest.raises(ValueError):
+        monitor = target.ApiTCPMonitor(**tcp_config)

--- a/f5_cccl/resource/ltm/monitor/test/test_udp_monitor.py
+++ b/f5_cccl/resource/ltm/monitor/test/test_udp_monitor.py
@@ -82,3 +82,15 @@ def test_create_api_monitor(udp_config):
     monitor = target.ApiUDPMonitor(**udp_config)
 
     assert isinstance(monitor, target.UDPMonitor)
+
+
+def test_create_monitors_invalid(udp_config):
+    # Set interval to be larger than timeout,
+    # ICR Monitor will be created, API Monitor will not
+    udp_config['interval'] = 30
+    monitor = target.IcrUDPMonitor(**udp_config)
+
+    assert isinstance(monitor, target.IcrUDPMonitor)
+
+    with pytest.raises(ValueError):
+        monitor = target.ApiUDPMonitor(**udp_config)

--- a/f5_cccl/resource/ltm/monitor/udp_monitor.py
+++ b/f5_cccl/resource/ltm/monitor/udp_monitor.py
@@ -58,4 +58,10 @@ class ApiUDPMonitor(UDPMonitor):
 
 class IcrUDPMonitor(UDPMonitor):
     """Create the canonical UDP monitor from API input."""
-    pass
+    def __init__(self, name, partition, **kwargs):
+        try:
+            super(IcrUDPMonitor, self).__init__(name, partition, **kwargs)
+        except ValueError:
+            # Need to allow for misconfigured legacy monitors from BIG-IP,
+            # so let this through
+            pass


### PR DESCRIPTION
Problem: For Health Monitors to function correctly, the interval
value should be less than the timeout value. BIG-IP versions prior
to v13.0 did not enforce this; however BIG-IP v13.0 does. Also,
BIG-IP v13.0 will actually change the interval value to be less than
the timeout if the input interval is greater than the timeout.

Solution: Enforce this relationship for API Health Monitors in CCCL.
Ignore it for ICR Health Monitors because these represent objects
that already exist on BIG-IP that we can't ignore.