### PR TITLE
Support Whitelisted resources

### DIFF
--- a/f5_cccl/resource/ltm/irule.py
+++ b/f5_cccl/resource/ltm/irule.py
@@ -31,13 +31,12 @@ class IRule(Resource):
     properties = dict(
         name=None,
         partition=None,
-        apiAnonymous=None,
-        metadata=list()
+        apiAnonymous=None
     )
 
     def __init__(self, name, partition, **data):
         """Create the iRule"""
-        super(IRule, self).__init__(name, partition)
+        super(IRule, self).__init__(name, partition, **data)
 
         self._data['metadata'] = data.get(
             'metadata',

--- a/f5_cccl/resource/ltm/node.py
+++ b/f5_cccl/resource/ltm/node.py
@@ -37,7 +37,7 @@ class Node(Resource):
 
     def __init__(self, name, partition, **properties):
         """Create a Node instance."""
-        super(Node, self).__init__(name, partition)
+        super(Node, self).__init__(name, partition, **properties)
 
         for key, value in self.properties.items():
             if key == "name" or key == "partition":

--- a/f5_cccl/resource/ltm/pool.py
+++ b/f5_cccl/resource/ltm/pool.py
@@ -35,12 +35,11 @@ class Pool(Resource):
                       loadBalancingMode="round-robin",
                       description=None,
                       monitor="default",
-                      membersReference={},
-                      metadata=list())
+                      membersReference={})
 
     def __init__(self, name, partition, members=None, **properties):
         u"""Create a Pool instance from CCCL poolType."""
-        super(Pool, self).__init__(name, partition)
+        super(Pool, self).__init__(name, partition, **properties)
 
         for key, value in self.properties.items():
             if key == "name" or key == "partition":

--- a/f5_cccl/resource/ltm/virtual.py
+++ b/f5_cccl/resource/ltm/virtual.py
@@ -63,12 +63,11 @@ class VirtualServer(Resource):
                       pool=None,
                       policies=list(),
                       profiles=list(),
-                      rules=list(),
-                      metadata=list())
+                      rules=list())
 
     def __init__(self, name, partition, default_route_domain, **properties):
         """Create a Virtual server instance."""
-        super(VirtualServer, self).__init__(name, partition)
+        super(VirtualServer, self).__init__(name, partition, **properties)
 
         for key, default in self.properties.items():
             if key in ["profiles", "policies"]:
@@ -171,6 +170,16 @@ class VirtualServer(Resource):
             destination = (self._data['destination'], None, None, None)
 
         return destination
+
+    def post_merge_adjustments(self):
+        """Re-sort order of resource properties after merge"""
+
+        for prop in ["profiles", "policies", "vlans"]:
+            if prop in self._data:
+                key = 'vlans' if prop == 'vlans' else 'name'
+                self._data[prop] = sorted(self._data[prop],
+                                          key=itemgetter(key))
+        super(VirtualServer, self).post_merge_adjustments()
 
     def __eq__(self, other):
         if not isinstance(other, VirtualServer):

--- a/f5_cccl/resource/ltm/virtual_address.py
+++ b/f5_cccl/resource/ltm/virtual_address.py
@@ -33,12 +33,11 @@ class VirtualAddress(Resource):
                       autoDelete="false",
                       enabled=None,
                       description=None,
-                      trafficGroup="/Common/traffic-group-1",
-                      metadata=list())
+                      trafficGroup="/Common/traffic-group-1")
 
     def __init__(self, name, partition, default_route_domain, **properties):
         """Create a VirtualAddress instance."""
-        super(VirtualAddress, self).__init__(name, partition)
+        super(VirtualAddress, self).__init__(name, partition, **properties)
 
         for key, value in self.properties.items():
             self._data[key] = properties.get(key, value)

--- a/f5_cccl/resource/test/test_merge_resource.py
+++ b/f5_cccl/resource/test/test_merge_resource.py
@@ -1,0 +1,719 @@
+#!/usr/bin/env python
+# Copyright (c) 2017,2018, F5 Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import copy
+import logging
+
+from f5_cccl.resource import Resource
+
+# allow logging to show up if test fails
+logging.basicConfig(level=logging.INFO)
+
+
+# Input data to simulate static Big-IP config with CCCL requested additions
+# and the resulting Big-IP 'merged' config.
+# Note: To reduce redundancy, if the expected merged result is the same as the
+#       initial Big-IP config, the mergedBigipProperties field is set to None.
+# Note2: If the mergedBigipProperties is what we want feed into the next
+#        'update', then the changedBigipProperties does not have to be listed.
+
+LTM_RESOURCE_TEST_DATA = [
+    # test top-level properties that are composed of simple dictionary entries
+    {
+        'name': 'CCCL no change no Bigip dict properties',
+        'initialBigipProperties': {},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': False,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL Add dict property, no BigIp dict property',
+        'initialBigipProperties': {},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': 3},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': 3}
+            },
+            {
+                'requestedCcclProperties': {'c': 3},
+                'updateRequired': False,
+                'mergedBigipProperties': {'c': 3}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': False,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL no change dict property',
+        'initialBigipProperties': {'a': 1, 'b': 2},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': False,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL Add dict property',
+        'initialBigipProperties': {'a': 1, 'b': 2},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': 3},
+                'updateRequired': True,
+                'mergedBigipProperties': {'a': 1, 'b': 2, 'c': 3}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'Modify CCCL Add dict property',
+        'initialBigipProperties': {'a': 1, 'b': 2},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': 3},
+                'updateRequired': True,
+                'mergedBigipProperties': {'a': 1, 'b': 2, 'c': 3}
+            },
+            {
+                'requestedCcclProperties': {'c': 4},
+                'updateRequired': True,
+                'mergedBigipProperties': {'a': 1, 'b': 2, 'c': 4}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'Replace CCCL Add dict property',
+        'initialBigipProperties': {'a': 1, 'b': 2},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': 3},
+                'updateRequired': True,
+                'mergedBigipProperties': {'a': 1, 'b': 2, 'c': 3}
+            },
+            {
+                'requestedCcclProperties': {'d': 4},
+                'updateRequired': True,
+                'mergedBigipProperties': {'a': 1, 'b': 2, 'd': 4}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'Bigip dynamic changes to dict property',
+        'initialBigipProperties': {},
+        'ltmUpdates': [
+            {  # Start with CCCL properties only
+                'requestedCcclProperties': {'b': 2, 'c': 3},
+                'updateRequired': True,
+                'mergedBigipProperties': {'b': 2, 'c': 3}
+            },
+            {  # Bigip adds a property 'a', we don't care
+                'changedBigipProperties': {'a': 1, 'b': 2, 'c': 3},
+                'requestedCcclProperties': {'b': 2, 'c': 3},
+                'updateRequired': False,
+                'mergedBigipProperties': {'b': 2, 'c': 3, 'a': 1}
+            },
+            { # Bigip tries to remove CCCL properties, we do care!
+                'changedBigipProperties': {'a': 1, 'c': 3},
+                'requestedCcclProperties': {'b': 2, 'c': 3},
+                'updateRequired': True,
+                'mergedBigipProperties': {'b': 2, 'c': 3, 'a': 1}
+            },
+            { # Bigip properties are removed, no matter the order
+                'changedBigipProperties': {'c': 3, 'b': 2},
+                'requestedCcclProperties': {'b': 2, 'c': 3},
+                'updateRequired': False,
+                'mergedBigipProperties': {'b': 2, 'c': 3}
+            },
+            { # Bigip modifies CCCL properties, must fix
+                'changedBigipProperties': {'b': 2, 'c': 4},
+                'requestedCcclProperties': {'b': 2, 'c': 3},
+                'updateRequired': True,
+                'mergedBigipProperties': {'b': 2, 'c': 3}
+            },
+            { # CCCL properties are removed
+                'changedBigipProperties': {'b': 2},
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    # test top-level property that is itself a list
+    # (note1: there is no such thing as 'replace' for simply lists)
+    # (note2: CCCL additions are always added to the front of the merged list)
+    {
+        'name': 'CCCL add empty list property, no BigIp property',
+        'initialBigipProperties': {},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': []},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': []}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL add one list property, no BigIp property',
+        'initialBigipProperties': {},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': ['firstProp']},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': ['firstProp']}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL add multi-entry list property, no BigIp property',
+        'initialBigipProperties': {},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': [1, 2]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [1, 2]}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL no list property, empty list BigIp property',
+        'initialBigipProperties': {'c': []},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': False,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL no list property, multi-entry list BigIp property',
+        'initialBigipProperties': {'c': [1, 2]},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': False,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL add dup list property, multi-entry list BigIp property',
+        'initialBigipProperties': {'c': [1, 2]},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': [1]},
+                'updateRequired': False,
+                'mergedBigipProperties': {'c': [1, 2]}
+            },
+            {
+                'requestedCcclProperties': {'c': [2]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [2, 1]}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': False,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL add list property, non-existent list BigIp property',
+        'initialBigipProperties': {},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': [3]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [3]}
+            },
+            {
+                'requestedCcclProperties': {'c': [4]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [4]}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL add list property, empty list BigIp property',
+        'initialBigipProperties': {'c': []},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': [3]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [3]}
+            },
+            {
+                'requestedCcclProperties': {'c': [4]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [4]}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL add unique list property, multi-entry list BigIp prop',
+        'initialBigipProperties': {'c': [1, 2]},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': [3]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [3, 1, 2]}
+            },
+            {
+                'requestedCcclProperties': {'c': [4]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [4, 1, 2]}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'Bigip dynamic changes to list property',
+        'initialBigipProperties': {'c': [1, 2]},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': [3, 4]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [3, 4, 1, 2]}
+            },
+            {
+                'requestedCcclProperties': {'c': [3, 4]},
+                'updateRequired': False,
+                'mergedBigipProperties': {'c': [3, 4, 1, 2]}
+            },
+            {
+                'changedBigipProperties': {'c': [3, 4, 2]},
+                'requestedCcclProperties': {'c': [3, 4]},
+                'updateRequired': False,
+                'mergedBigipProperties': {'c': [3, 4, 2]}
+            },
+            {
+                'changedBigipProperties': {'c': [3, 4, 2]},
+                'requestedCcclProperties': {'c': [3, 4]},
+                'updateRequired': False,
+                'mergedBigipProperties': {'c': [3, 4, 2]}
+            },
+            {
+                'changedBigipProperties': {'c': [2, 3, 4]},
+                'requestedCcclProperties': {'c': [3, 4]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [3, 4, 2]}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [2]}
+            }
+        ]
+    },
+    # This following test fails for jsonpatch versions 1.20-1.23.
+    # It only works for version 1.16 and that behavior is required
+    # for proper merging of Big-IP objects.
+    {
+        'name': 'Bigip dynamic large changes to list property',
+        'initialBigipProperties': {'c': [2, 4, 6, 8]},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': [1, 3, 5, 7]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [1, 3, 5, 7, 2, 4, 6, 8]}
+            },
+            {
+                'changedBigipProperties': {'c': [3, 7, 4, 8]},
+                'requestedCcclProperties': {'c': [1, 3, 5]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [1, 3, 5, 4, 8]}
+            },
+            {
+                'changedBigipProperties': {'c': [1, 2, 3, 4, 5, 8]},
+                'requestedCcclProperties': {'c': []},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [2, 4, 8]}
+            }
+        ],
+    },
+    # test top-level list properties that are dictionaries themselves
+    # (note1: this takes into account specific Big-IP behavior in that
+    #         these dictionaries can be uniquely identified by a 'name'
+    #         attribute.  Therefore, we can perform a 'replace' or 'modify'
+    #         of the individual list entries.)
+    # (note2: CCCL additions are always added to the front of the merged list)
+    {
+        'name': 'CCCL add dict list property, no BigIp property',
+        'initialBigipProperties': {},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': [{'name': 'a', 'value': 1}]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [{'name': 'a', 'value': 1}]}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL add dict list property, existing BigIp property',
+        'initialBigipProperties': {'c': [{'name': 'b', 'value': 0}]},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': [{'name': 'a', 'value': 1}]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [{'name': 'a', 'value': 1},
+                                                {'name': 'b', 'value': 0}]}
+            },
+            {
+                'requestedCcclProperties': {'c': [{'name': 'c', 'value': 2}]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [{'name': 'c', 'value': 2},
+                                                {'name': 'b', 'value': 0}]}
+            },
+            {
+                'requestedCcclProperties': {'c': [{'name': 'c', 'value': 2}]},
+                'updateRequired': False,
+                'mergedBigipProperties': {'c': [{'name': 'c', 'value': 2},
+                                                {'name': 'b', 'value': 0}]}
+            },
+            {
+                'requestedCcclProperties': {'c': [{'name': 'c', 'value': 2},
+                                                  {'name': 'd', 'value': 3}]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [{'name': 'c', 'value': 2},
+                                                {'name': 'd', 'value': 3},
+                                                {'name': 'b', 'value': 0}]}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL modify dict list property of BigIp property',
+        'initialBigipProperties': {'c': [{'name': 'b', 'value': 0}]},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {'c': [{'name': 'b', 'value': 1}]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [{'name': 'b', 'value': 1}]}
+            },
+            {
+                'requestedCcclProperties': {'c': [{'name': 'b', 'value2': 2}]},
+                'updateRequired': True,
+                'mergedBigipProperties': {'c': [{'name': 'b', 'value2': 2}]}
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL modify complex dict list property of BigIp property',
+        'initialBigipProperties': {'c': [{'name': 'b', 'val': 0, 'val2': 1},
+                                         {'name': 'd', 'val': 2, 'val3': 3}]},
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {
+                    'a': [0, 1, 2],
+                    'b': "just text",
+                    'c': [{'name': 'b', 'val': 0, 'val2': 1},
+                          {'name': 'c', 'val': 1, 'val3': 3},
+                          {'name': '0', 'val': 9, 'val3': 9}]
+                },
+                'updateRequired': True,
+                'mergedBigipProperties': {
+                    'a': [0, 1, 2],
+                    'b': "just text",
+                    'c': [{'name': 'b', 'val': 0, 'val2': 1},
+                          {'name': 'c', 'val': 1, 'val3': 3},
+                          {'name': '0', 'val': 9, 'val3': 9},
+                          {'name': 'd', 'val': 2, 'val3': 3}]
+                },
+            },
+            {
+                'requestedCcclProperties': {
+                    'a': [0, 1, 2],
+                    'b': "just text",
+                    'c': [{'name': 'b', 'val': 0, 'val2': 1},
+                          {'name': 'c', 'val': 1, 'val3': 3},
+                          {'name': '0', 'val': 9, 'val3': 9}]
+                },
+                'updateRequired': False,
+                'mergedBigipProperties': {
+                    'a': [0, 1, 2],
+                    'b': "just text",
+                    'c': [{'name': 'b', 'val': 0, 'val2': 1},
+                          {'name': 'c', 'val': 1, 'val3': 3},
+                          {'name': '0', 'val': 9, 'val3': 9},
+                          {'name': 'd', 'val': 2, 'val3': 3}]
+                },
+            },
+            {
+                'requestedCcclProperties': {
+                    'c': [{'name': 'b', 'val1': 0, 'val2': 0}]
+                },
+                'updateRequired': True,
+                'mergedBigipProperties': {
+                    'c': [{'name': 'b', 'val1': 0, 'val2': 0},
+                          {'name': 'd', 'val': 2, 'val3': 3}]
+                },
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    },
+    {
+        'name': 'CCCL real Big-IP example',
+        'initialBigipProperties': {
+            'connectionLimit': 0,
+            'ipProtocol': 'tcp',
+            'destination': '/test/172.16.3.60%0:443',
+            'sourceAddressTranslation': {
+                'type': 'none'
+            },
+            'rules': [
+                '/common/custom_irule'
+            ],
+            'profiles': [
+                {
+                    'partition': 'Common',
+                    'name': 'tcp',
+                    'context': 'all'
+                },
+                {
+                    'partition': 'Common',
+                    'name': 'http',
+                    'context': 'all'
+                },
+                {
+                    'partition': 'Common',
+                    'name': 'html',
+                    'context': 'all'
+                }
+            ]
+        },
+        'ltmUpdates': [
+            {
+                'requestedCcclProperties': {
+                    'connectionLimit': 0,
+                    'ipProtocol': 'tcp',
+                    'destination': '/test/172.16.3.60%0:443',
+                    'sourceAddressTranslation': {
+                        'type': 'automap'
+                    },
+                    'rules': [
+                        '/test/openshift_passhtrough_irule'
+                    ],
+                    'profiles': [
+                        {
+                            'partition': 'Common',
+                            'name': 'tcp',
+                            'context': 'all'
+                        },
+                        {
+                            'partition': 'Common',
+                            'name': 'http',
+                            'context': 'all'
+                        }
+                    ]
+                },
+                'updateRequired': True,
+                'mergedBigipProperties': {
+                    'connectionLimit': 0,
+                    'ipProtocol': 'tcp',
+                    'destination': '/test/172.16.3.60%0:443',
+                    'sourceAddressTranslation': {
+                        'type': 'automap'
+                    },
+                    'rules': [
+                        '/test/openshift_passhtrough_irule',
+                        '/common/custom_irule'
+                    ],
+                    'profiles': [
+                        {
+                            'partition': 'Common',
+                            'name': 'tcp',
+                            'context': 'all'
+                        },
+                        {
+                            'partition': 'Common',
+                            'name': 'http',
+                            'context': 'all'
+                        },
+                        {
+                            'partition': 'Common',
+                            'name': 'html',
+                            'context': 'all'
+                        }
+                    ]
+                }
+            },
+            {
+                'requestedCcclProperties': {},
+                'updateRequired': True,
+                'mergedBigipProperties': None
+            }
+        ]
+    }
+]
+
+
+class GenericResource(Resource):
+    """Mock resource"""
+
+    def __init__(self, properties):
+        super(GenericResource, self).__init__("testResource",
+                                              "testPartition",
+                                              **properties)
+
+        for key, value in properties.items():
+            self._data[key] = value
+
+    def scrub_data(self, include_metadata = False):
+        """Remove programmatically added properties"""
+        data = copy.deepcopy(self._data)
+        if include_metadata:
+            del data['metadata']
+        del data['name']
+        del data['partition']
+        return data
+
+    def replace_data(self, data):
+        """Remove programmatically added properties"""
+        metadata = self._data['metadata']
+        name = self._data['name']
+        partition = self._data['partition']
+        self._data = copy.deepcopy(data)
+        self._data['metadata'] = metadata
+        self._data['name'] = name
+        self._data['partition'] = partition
+
+
+def _add_whitelist_metadata(orig_data):
+    """Turn this resource into a whitelisted resource"""
+
+    data = copy.deepcopy(orig_data)
+    data['metadata'] = [
+        {
+            'name': 'cccl-whitelist',
+            'app-service': 'none',
+            'persist': True,
+            'value': 1
+        }
+    ]
+    return data
+
+
+def test_merge_cccl_resource_properties():
+    """Test merge and revert when CCCL resource is added, modified, removed"""
+    for test in LTM_RESOURCE_TEST_DATA:
+        initial_properties = \
+            _add_whitelist_metadata(test['initialBigipProperties'])
+        current_bigip_resource = GenericResource(initial_properties)
+
+        # cycle through each update request and verify proper merge
+        # (the Big-IP current state is the final state of the previous update)
+        for ltm_update in test['ltmUpdates']:
+            print("Running test '{}'".format(test['name']))
+            if 'changedBigipProperties' in ltm_update:
+                # Simulates BigIP changing on the fly
+                current_bigip_resource.replace_data(
+                    ltm_update['changedBigipProperties'])
+            update_required = current_bigip_resource.merge(
+                ltm_update['requestedCcclProperties'])
+            assert ltm_update['updateRequired'] == update_required, \
+                    "Failed test: {}".format(test['name'])
+            # assume the initial BigIP properties if we don't specify them
+            expected_bigip_resource = ltm_update['mergedBigipProperties'] \
+                if ltm_update['mergedBigipProperties'] \
+                else test['initialBigipProperties']
+            assert expected_bigip_resource == \
+                   current_bigip_resource.scrub_data(include_metadata=True), \
+                   "Failed test: {}".format(test['name'])
+
+            # Prepare next pass to simulate retrieval from Big-IP
+            current_data = copy.deepcopy(current_bigip_resource.scrub_data())
+            current_bigip_resource = GenericResource(current_data)

--- a/f5_cccl/resource/test/test_resource.py
+++ b/f5_cccl/resource/test/test_resource.py
@@ -242,6 +242,69 @@ def test_set_data():
         res.data = {}
 
 
+def test_ignore_unknown_properties():
+    u"""Test Resource unknown base properties."""
+    data = resource_data()
+    data['prop1'] = 'property1'
+    data['prop2'] = 'property2'
+    assert len(data) == 4
+
+    res = Resource(**data)
+
+    assert len(res.data) == 2
+    assert res.whitelist is False
+
+    with pytest.raises(KeyError):
+        _ = res.data['prop1']
+    with pytest.raises(KeyError):
+        _ = res.data['prop2']
+    assert res.data['name'] == 'test_resource'
+    assert res.data['partition'] == 'Common'
+
+
+def test_metedata_not_set():
+    u"""Test Resource data update."""
+    data = resource_data()
+
+    res = Resource(**data)
+
+    assert res.whitelist is False
+
+
+def test_unsupported_metedata_property():
+    u"""Test Resource data update."""
+    data = resource_data()
+    data['metadata'] = [{'name': 'unsupported', 'value': '0'}]
+
+    res = Resource(**data)
+
+    # unsupported metadata is ignored
+    assert len(res.data) == 3
+    assert res.whitelist is False
+
+
+def test_whitelist_true_metedata_property():
+    u"""Test Resource data update."""
+    data = resource_data()
+    data['metadata'] = [{'name': 'cccl-whitelist', 'value': 'true'}]
+
+    res = Resource(**data)
+
+    assert len(res.data) == 3
+    assert res.whitelist is True
+
+
+def test_whitelist_false_metedata_property():
+    u"""Test Resource data update."""
+    data = resource_data()
+    data['metadata'] = [{'name': 'cccl-whitelist', 'value': 'false'}]
+
+    res = Resource(**data)
+
+    assert len(res.data) == 3
+    assert res.whitelist is False
+
+
 def test_create_subresource(bigip):
     u"""Test that a subclass of Resource will execute 'create'."""
     data = resource_data()

--- a/f5_cccl/service/config_reader.py
+++ b/f5_cccl/service/config_reader.py
@@ -69,6 +69,7 @@ class ServiceConfigReader(object):
 
         # Update the object with metadata
         if user_agent is not None:
+
             metadata = {
                 'metadata': [{
                     'name': 'user_agent',

--- a/f5_cccl/service/test/test_service_manager.py
+++ b/f5_cccl/service/test/test_service_manager.py
@@ -203,6 +203,8 @@ class TestServiceConfigDeployer:
     def test_virtual_servers(self, ltm_service_manager):
         """Test create/update/delete of Virtual Servers."""
         # Should create one Virtual Server 
+        #  and ignore Big-IP virtuals not in the partition (/Common/virtual1)
+        # or have the cccl-whitelist metadata set (test/virtual3)
         objs = self.get_created_ltm_objects(ltm_service_manager, VirtualServer)
         assert 1 == len(objs)
         assert objs[0].name == 'vs1'

--- a/f5_cccl/test/bigip_data.json
+++ b/f5_cccl/test/bigip_data.json
@@ -69,6 +69,13 @@
             "ipProtocol": "tcp",
             "kind": "tm:ltm:virtual:virtualstate",
             "mask": "255.255.255.255",
+            "metadata": [
+                {
+                    "name": "cccl-whitelist",
+                    "persist": "true",
+                    "value": "false"
+                }
+            ],
             "mirror": "disabled",
             "mobileAppTunnel": "disabled",
             "name": "virtual2",
@@ -91,6 +98,61 @@
             "rateLimitMode": "object",
             "rateLimitSrcMask": 0,
             "selfLink": "https://localhost/mgmt/tm/ltm/virtual/~test~virtual2?ver=12.1.0",
+            "serviceDownImmediateAction": "none",
+            "source": "0.0.0.0/0",
+            "sourceAddressTranslation": {
+                "type": "none"
+            },
+            "sourcePort": "preserve",
+            "synCookieStatus": "not-activated",
+            "translateAddress": "enabled",
+            "translatePort": "enabled",
+            "vlansDisabled": true,
+            "vsIndex": 112
+        },
+        {
+            "addressStatus": "yes",
+            "autoLasthop": "default",
+            "cmpEnabled": "yes",
+            "connectionLimit": 0,
+            "description": "This is a virtual server",
+            "destination": "/test/10.190.6.8:80",
+            "enabled": true,
+            "fullPath": "/test/virtual3",
+            "generation": 15858,
+            "gtmScore": 0,
+            "ipProtocol": "tcp",
+            "kind": "tm:ltm:virtual:virtualstate",
+            "mask": "255.255.255.255",
+            "metadata": [
+                {
+                    "name": "cccl-whitelist",
+                    "persist": "true",
+                    "value": "true"
+                }
+            ],
+            "mirror": "disabled",
+            "mobileAppTunnel": "disabled",
+            "name": "virtual3",
+            "nat64": "disabled",
+            "partition": "test",
+            "policiesReference": {
+                "isSubcollection": true,
+                "link": "https://localhost/mgmt/tm/ltm/virtual/~test~virtual3/policies?ver=12.1.0"
+            },
+            "pool": "/test/pool1",
+            "poolReference": {
+                "link": "https://localhost/mgmt/tm/ltm/pool/~test~pool1?ver=12.1.0"
+            },
+            "profilesReference": {
+                "isSubcollection": true,
+                "link": "https://localhost/mgmt/tm/ltm/virtual/~test~virtual3/profiles?ver=12.1.0"
+            },
+            "rateLimit": "disabled",
+            "rateLimitDstMask": 0,
+            "rateLimitMode": "object",
+            "rateLimitSrcMask": 0,
+            "selfLink": "https://localhost/mgmt/tm/ltm/virtual/~test~virtual3?ver=12.1.0",
             "serviceDownImmediateAction": "none",
             "source": "0.0.0.0/0",
             "sourceAddressTranslation": {

--- a/f5_cccl/test/test_bigip.py
+++ b/f5_cccl/test/test_bigip.py
@@ -63,7 +63,7 @@ def test_bigip_refresh_ltm(bigip_proxy):
 
     # verify virtual servers 
     assert big_ip.tm.ltm.virtuals.get_collection.called
-    assert len(bigip_proxy._virtuals) == 1
+    assert len(bigip_proxy._virtuals) == 2
 
     assert len(bigip_proxy._virtuals) == len(test_virtuals)
     for v in test_virtuals:

--- a/f5_cccl/utils/json_pos_patch.py
+++ b/f5_cccl/utils/json_pos_patch.py
@@ -1,0 +1,149 @@
+"""Provides functions for making jsonpatch positionally independent."""
+# coding=utf-8
+#
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import hashlib
+import json
+import logging
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def convert_from_positional_patch(data, patch_obj):
+    """Replace array indexes with unique ID (hash).
+
+       Patches that refer to an array index must be modified so
+       that they refer to the hash value of the content (whether it's
+       a simple value or a complex dictionary).
+
+       Patches are a list of dictionaries values with each value
+       specifying a json path, an operation, and possibly a value.
+       For example:
+           {'path': '/c/0/value', 'value': 1, 'op': 'replace'}
+       (other operations are 'add', 'remove', and 'move')
+
+       Note:  This requires the content to be unique among array entries
+              (seems to be the case for Big-IP objects)
+    """
+
+    LOGGER.debug("convert_from_positional_patch data: %s", data)
+    if patch_obj is None:
+        return
+    patch = patch_obj.patch
+    LOGGER.debug("convert_from_positional_patch indexed patch: %s", patch)
+
+    for entry in patch:
+        ptr = data
+        new_path = ""
+        for sub_path in entry['path'].split('/'):
+            if not sub_path:
+                # ignore the first subpath (before the leading slash)
+                continue
+            elif ptr is None:
+                # continue to add path since we are done with substitutions
+                new_path += '/'
+                new_path += sub_path
+            elif sub_path.isdigit():
+                new_path += '/'
+                ptr = ptr[int(sub_path)]
+                str_content = json.dumps(ptr)
+                new_path += \
+                    '[{}]'.format(hashlib.sha256(bytes(
+                        str_content.encode('utf-8'))).hexdigest())
+            else:
+                new_path += '/'
+                new_path += sub_path
+                if sub_path in ptr:
+                    ptr = ptr[sub_path]
+                else:
+                    # done with substitutions, so just finish up remaining path
+                    ptr = None
+        entry['path'] = new_path
+    LOGGER.debug("convert_from_positional_patch hashed patch: %s",
+                 patch_obj.patch)
+
+
+def convert_to_positional_patch(data,  # pylint: disable=too-many-branches
+                                patch_obj):
+    """Replace arrays indexed by a hash value with a positional index value.
+
+       The index ID is the shasum hash value of the object.  If the ID isn't
+       found remove the patch entry.
+
+       Note: A limitation of this function is if the user managed to
+             change the content of the hashed object, we would treat
+             it as a uniquely different object. Fortunately, this
+             doesn't seem possible with Big-IP gui.
+    """
+
+    LOGGER.debug("convert_to_positional_patch data: %s", data)
+    if patch_obj is None:
+        return
+    patch = patch_obj.patch
+    LOGGER.debug("convert_to_positional_patch hashed patch: %s", patch)
+
+    entry_cnt = len(patch)
+    entry_idx = 0
+    while entry_idx < entry_cnt:
+        entry = patch[entry_idx]
+        ptr = data
+        new_path = ""
+        for sub_path in entry['path'].split('/'):
+            if not sub_path:
+                # ignore the first subpath (before the leading slash)
+                continue
+            elif ptr is None:
+                # continue to add path since we are done with substitutions
+                new_path += '/'
+                new_path += sub_path
+            elif sub_path[0] == '[' and sub_path[len(sub_path)-1] == ']':
+                uuid = sub_path[1:-1]
+                new_path += '/'
+                for content_idx, content in enumerate(ptr):
+                    str_content = json.dumps(content)
+                    content_uuid = hashlib.sha256(bytes(
+                        str_content.encode('utf-8'))).hexdigest()
+                    if content_uuid == uuid:
+                        new_path += str(content_idx)
+                        ptr = ptr[content_idx]
+                        break
+                else:
+                    # entry no longer exists so we can't remove it
+                    new_path = None
+                    break
+            else:
+                new_path += '/'
+                new_path += sub_path
+                if sub_path in ptr:
+                    ptr = ptr[sub_path]
+                else:
+                    # done with substitutions so just finish up remaining path
+                    ptr = None
+                    if entry['op'] == 'remove':
+                        # entry no longer exists so we must delete this patch
+                        new_path = None
+                        break
+        if new_path:
+            entry['path'] = new_path
+            entry_idx += 1
+        else:
+            del patch[entry_idx]
+            entry_cnt -= 1
+    LOGGER.debug("convert_to_positional_patch indexed patch: %s",
+                 patch_obj.patch)

--- a/f5_cccl/utils/resource_merge.py
+++ b/f5_cccl/utils/resource_merge.py
@@ -1,0 +1,131 @@
+"""Provides functions for merging identical BIG-IP resources togehter."""
+# coding=utf-8
+#
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import copy
+import logging
+
+from functools import reduce as reducer  # name conflict between python 2 & 3
+from itertools import groupby
+from operator import itemgetter
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _merge_dict_by():
+    """Returns a function that merges two dictionaries dst and src.
+
+       Keys are merged together between the dst and src dictionaries.
+       If there is a conflict, the src values take precedence.
+    """
+
+    return lambda dst, src: {
+        key: src[key] if key in src else dst[key]
+        for key in list(set(dst.keys()) | set(src.keys()))
+    }
+
+
+def _merge_list_of_dict_by(key):
+    """Returns a function that merges a list of dictionary records
+
+       Records are grouped by the specified key.
+    """
+
+    keyprop = itemgetter(key)
+    return lambda lst: [
+        reducer(_merge_dict_by(), records)
+        for _, records in groupby(sorted(lst, key=keyprop), keyprop)
+    ]
+
+
+def _merge_list_of_dict_by_name(dst, src):
+    """Merge list of Big-IP dictionary records uniquely identified by name.
+
+       Duplicates are not merged, but replaced. Src is added to front.
+    """
+    merge_list = []
+    merge_set = set()
+    for record in src:
+        merge_list.append(record)
+        merge_set.add(record['name'])
+    for record in dst:
+        if record['name'] not in merge_set:
+            merge_list.append(record)
+    return merge_list
+
+
+def _merge_list_of_scalars(dst, src):
+    """Merge list of scalars (add src first, then remaining unique dst)"""
+    dst_copy = copy.copy(dst)
+    src_set = set(src)
+    dst = copy.copy(src)
+    for val in dst_copy:
+        if val not in src_set:
+            dst.append(val)
+    return dst
+
+
+def _merge_list(dst, src):
+    """Merge lists of a particular type
+
+       Limitations: lists must be of a uniform type: scalar, list, or dict
+    """
+
+    if not dst:
+        return src
+    elif isinstance(dst[0], dict):
+        dst = _merge_list_of_dict_by_name(dst, src)
+    elif isinstance(dst[0], list):
+        # May cause duplicates (what is a duplicate for lists of lists?)
+        dst = src + dst
+    else:
+        dst = _merge_list_of_scalars(dst, src)
+    return dst
+
+
+def _merge_dict(dst, src):
+    """Merge two dictionaries together, with src overridding dst fields."""
+
+    for key in src.keys():
+        dst[key] = merge(dst[key], src[key]) if key in dst else src[key]
+    return dst
+
+
+def merge(dst, src):
+    """Merge two resources together with the src fields taking precedence.
+
+       Note: this is specifically tailored for Big-IP resources and
+             does not generically support all type variations)
+    """
+
+    LOGGER.debug("Merging source: %s", src)
+    LOGGER.debug("Merging destination: %s", dst)
+    # pylint: disable=C0123
+    if type(dst) != type(src):
+        # can't merge differing types, src wins everytime
+        # (maybe this should be an error)
+        dst = copy.deepcopy(src)
+    elif isinstance(dst, dict):
+        return _merge_dict(dst, src)
+    elif isinstance(dst, list):
+        return _merge_list(dst, src)
+    else:
+        # scalar
+        dst = src
+    LOGGER.debug("Merged result: %s", dst)
+    return dst

--- a/f5_cccl/utils/test/test_json_pos_patch.py
+++ b/f5_cccl/utils/test/test_json_pos_patch.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import jsonpatch
+
+import f5_cccl.utils.json_pos_patch as pospatch
+
+from f5_cccl.utils.resource_merge import merge
+
+#
+# These tests verify that JSON patches can be converted to a positionally
+# independent patch and then reverted back again, assuming the original
+# data has not changed (if so, the patches should be trimmed)
+#
+def test_json_simple_property():
+    """ Test simple dict """
+
+    dataIn = {
+        'a': 1,
+        'b': 2,
+        'c': 3
+    }
+    dataOut1 = {
+        'a': 1,
+        'b': 2,
+        'c': 3
+    }
+    dataOut2 = {
+        'c': 3,
+        'b': 2,
+        'a': 1
+    }
+    dataOut3 = {
+        'a': 1,
+        'b': 2
+    }
+    dataOut4 = {
+        'b': 2
+    }
+    dataOut5 = {
+    }
+
+    patch_strIn = '[{"path": "/a", "op": "remove"}]'
+    patch_strOutPropExists = '[{"path": "/a", "op": "remove"}]'
+    patch_strOutPropNotExists = '[]'
+
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOutPropExists)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut1, patch)
+    assert patch == expected_patch
+
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOutPropExists)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut2, patch)
+    assert patch == expected_patch
+
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOutPropExists)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut3, patch)
+    assert patch == expected_patch
+
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOutPropNotExists)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut4, patch)
+    assert patch == expected_patch
+
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOutPropNotExists)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut5, patch)
+    assert patch == expected_patch
+
+
+def test_json_simple_array():
+    """ Test simple arrays """
+
+    dataIn = {
+        'rules': [
+            'A',
+            'B',
+        ],
+    }
+    dataOut1 = {
+        'rules': [
+            'A',
+            'B',
+        ],
+    }
+    dataOut2 = {
+        'rules': [
+            'B',
+            'A',
+        ],
+    }
+    dataOut3 = {
+        'rules': [
+            'A',
+        ],
+    }
+    dataOut4 = {
+        'rules': [
+            'B',
+        ],
+    }
+
+    patch_strIn = '[{"path": "/rules/1", "op": "remove"}]'
+    patch_strOut1 = '[{"path": "/rules/1", "op": "remove"}]'
+    patch_strOut2 = '[{"path": "/rules/0", "op": "remove"}]'
+    patch_strOut3 = '[]'
+    patch_strOut4 = '[{"path": "/rules/0", "op": "remove"}]'
+
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOut1)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut1, patch)
+    assert patch == expected_patch
+
+    # Test that if the order is switched (user rearranges the
+    # order on the Big-IP), the patching still works correctly
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOut2)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut2, patch)
+    assert patch == expected_patch
+
+    # Test if the patched entry is deleted (e.g. user deleted a
+    # rule/policy on the Big-IP)
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOut3)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut3, patch)
+    assert patch == expected_patch
+
+    # Test if another entry is deleted (e.g. user deleted a
+    # rule/policy on the Big-IP)
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOut4)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut4, patch)
+    assert patch == expected_patch
+
+
+def test_json_compound_array():
+    """ Test arrays of dictionaries """
+
+    dataIn = {
+        'profiles': [
+            {
+                'partition': 'Common',
+                'name': 'http',
+                'context': 'all'
+            },
+            {
+                'partition': 'Common',
+                'name': 'tcp',
+                'context': 'all'
+            }
+        ],
+    }
+    dataOut1 = {
+        'profiles': [
+            {
+                'partition': 'Common',
+                'name': 'http',
+                'context': 'all'
+            },
+            {
+                'partition': 'Common',
+                'name': 'tcp',
+                'context': 'all'
+            }
+        ]
+    }
+    dataOut2 = {
+        'profiles': [
+            {
+                'partition': 'Common',
+                'name': 'tcp',
+                'context': 'all'
+            }
+        ]
+    }
+    dataOut3 = {
+        'profiles': [
+            {
+                'partition': 'Common',
+                'name': 'http',
+                'context': 'all'
+            },
+            {
+                'partition': 'Common',
+                'name': 'tcp',
+            }
+        ]
+    }
+    dataOut4 = {
+        'profiles': [
+            {
+                'partition': 'Common',
+                'name': 'http',
+                'context': 'all'
+            }
+        ]
+    }
+
+    patch_strIn = \
+        '[{"path": "/profiles/1/context", "value": "none", "op": "replace"}]'
+    patch_strOut1 = \
+        '[{"path": "/profiles/1/context", "value": "none", "op": "replace"}]'
+    patch_strOut2 = \
+        '[{"path": "/profiles/0/context", "value": "none", "op": "replace"}]'
+    patch_strOut3 = \
+        '[]'
+    patch_strOut4 = '[]'
+
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOut1)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut1, patch)
+    assert patch == expected_patch
+
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOut2)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut2, patch)
+    assert patch == expected_patch
+
+    # if an array entry is modified by user, we must treat it as a new
+    # entry and will not attempt to patch it (fortunately, this does not
+    # seem possible on the Big-IP).
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOut3)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut3, patch)
+    assert patch == expected_patch
+
+    patch = jsonpatch.JsonPatch.from_string(patch_strIn)
+    expected_patch = jsonpatch.JsonPatch.from_string(patch_strOut4)
+    pospatch.convert_from_positional_patch(dataIn, patch)
+    pospatch.convert_to_positional_patch(dataOut4, patch)
+    assert patch == expected_patch

--- a/f5_cccl/utils/test/test_resource_merge.py
+++ b/f5_cccl/utils/test/test_resource_merge.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from f5_cccl.utils.resource_merge import merge
+
+#
+# CCCL merge takes it's required resource properties and
+# merges it into the Big-IP existing properties.  If there
+# is a conflict, the CCCL properties win.  Also, for lists
+# CCCL entries are listed first.
+#
+
+def test_resource_merge_scalars():
+    """ Test simple scalar merging (replacing) """
+
+    test_data = [
+        # desired, existing, merged
+        (4, 3, 4),
+        ('a', 'b', 'a'),
+        (True, False, True)
+    ]
+    for test in test_data:
+        desired = test[0]
+        existing = test[1]
+        expected = test[2]
+        assert merge(existing, desired) == expected
+
+
+def test_resource_merge_simple_arrays():
+    """ Test simple list merging (replacing) """
+
+    test_data = [
+        # desired, existing, merged
+        ([], [], []),
+        ([], [1], [1]),
+        ([1], [], [1]),
+        ([1], [2], [1, 2]),
+        ([2], [1], [2, 1]),
+        ([1, 2], [1], [1, 2]),
+        ([1], [1, 2], [1, 2]),
+        ([1, 3], [1, 2], [1, 3, 2]),
+        (['apple', 'orange'], ['apple', 'pear'], ['apple', 'orange', 'pear'])
+    ]
+    for test in test_data:
+        desired = test[0]
+        existing = test[1]
+        expected = test[2]
+        assert merge(existing, desired) == expected
+
+
+def test_resource_merge_simple_dict():
+    """ Test simple dictionary merging """
+
+    test_data = [
+        # desired, existing, merged
+        ({}, {'a': 1}, {'a': 1}),
+        ({'a': 1}, {}, {'a': 1}),
+        ({'a': 1}, {'a': 2}, {'a': 1}),
+        ({'a': 1}, {'b': 2}, {'a': 1, 'b': 2}),
+        ({'a': 1, 'b': 3}, {'b': 2}, {'a': 1, 'b': 3}),
+        ({'a': 1, 'b': 2}, {'c': 3, 'd': 4}, {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+    ]
+    for test in test_data:
+        desired = test[0]
+        existing = test[1]
+        expected = test[2]
+        assert merge(existing, desired) == expected
+
+
+def test_resource_merge_list_of_named_dict():
+    """ Test merge lists of named dictionary objects
+
+        This is unique for Big-IP resources that are
+        lists of named objects (the resources must have
+        a unique property 'name').
+    """
+
+    test_data = [
+        # desired, existing, merged
+        (
+            [],
+            [],
+            []
+        ),
+        (
+            [],
+            [{'name': 'resource-a', 'value': 1}],
+            [{'name': 'resource-a', 'value': 1}]
+        ),
+        (
+            [{'name': 'resource-a', 'value': 1}],
+            [],
+            [{'name': 'resource-a', 'value': 1}]),
+        (
+            [{'name': 'resource-a', 'value': 1}],
+            [{'name': 'resource-a', 'value': 3}],
+            [{'name': 'resource-a', 'value': 1}]
+        ),
+        (
+            [{'name': 'resource-a', 'value1': 1, 'value2': 2}],
+            [{'name': 'resource-a', 'value2': 0, 'value3': 3}],
+            [{'name': 'resource-a', 'value1': 1, 'value2': 2}]
+        ),
+        (
+            [
+                {'name': 'resource-a', 'value1': 1, 'value2': 2},
+                {'name': 'resource-b', 'valueB': 'b'}
+            ],
+            [
+                {'name': 'resource-a', 'value2': 0, 'value3': 3},
+                {'name': 'resource-c', 'valueC': 'c'},
+                {'name': 'resource-b', 'valueB': 'b'}
+            ],
+            [
+                {'name': 'resource-a', 'value1': 1, 'value2': 2},
+                {'name': 'resource-b', 'valueB': 'b'},
+                {'name': 'resource-c', 'valueC': 'c'}
+            ]
+        )
+    ]
+    for test in test_data:
+        desired = test[0]
+        existing = test[1]
+        expected = test[2]
+        assert merge(existing, desired) == expected
+
+
+def test_resource_merge_sample_resource():
+    """ Test actual Big-IP resource """
+
+    desired = {
+        'destination': '/test/172.16.3.59%0:80',
+        'name': 'ingress_172-16-3-59_80',
+        'rules': [],
+        'vlansDisabled': True,
+        'enabled': True,
+        'sourceAddressTranslation': {'type': 'automap'},
+        'partition': 'test',
+        'source': '0.0.0.0%0/0',
+        'profiles': [
+            {'partition': 'Common', 'name': 'http', 'context': 'all'},
+            {'partition': 'Common', 'name': 'tcp', 'context': 'all'}
+        ],
+        'connectionLimit': 0,
+        'ipProtocol': 'tcp',
+        'vlans': [],
+        'policies': [
+            {'partition': 'test', 'name': 'ingress_172-16-3-59_80'}
+        ]
+    }
+
+    existing = {
+        'destination': '/test/172.16.3.59%0:80',
+        'name': 'ingress_172-16-3-59_80',
+        'rules': [],
+        'vlansDisabled': False,  # should change
+        'enabled': True,
+        'sourceAddressTranslation': {'type': 'snat'},  # should change
+        'partition': 'test',
+        'source': '0.0.0.0%0/0',
+        'profiles': [
+            # html profile should be kept, but added after CCCL entries
+            {'partition': 'Common', 'name': 'html', 'context': 'all'},
+            {'partition': 'Common', 'name': 'http', 'context': 'all'},
+            {'partition': 'Common', 'name': 'tcp', 'context': 'all'}
+        ],
+        'connectionLimit': 1,  # should change
+        'ipProtocol': 'tcp',
+        'vlans': [
+            {'name': 'vlan', 'a': '1', 'b': '2'}  # should be kept
+        ],
+        'policies': []  # will be added to
+    }
+
+    expected = {
+        'destination': '/test/172.16.3.59%0:80',
+        'name': 'ingress_172-16-3-59_80',
+        'rules': [],
+        'vlansDisabled': True,
+        'enabled': True,
+        'sourceAddressTranslation': {'type': 'automap'},
+        'partition': 'test',
+        'source': '0.0.0.0%0/0',
+        'profiles': [
+            {'partition': 'Common', 'name': 'http', 'context': 'all'},
+            {'partition': 'Common', 'name': 'tcp', 'context': 'all'},
+            {'partition': 'Common', 'name': 'html', 'context': 'all'}
+        ],
+        'connectionLimit': 0,
+        'ipProtocol': 'tcp',
+        'vlans': [
+            {'name': 'vlan', 'a': '1', 'b': '2'}
+        ],
+        'policies': [
+            {'partition': 'test', 'name': 'ingress_172-16-3-59_80'}
+        ]
+    }
+
+    assert merge(existing, desired) == expected

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -18,5 +18,6 @@ q
 PyYAML==3.12
 simplejson
 jsonschema
+jsonpatch==1.16
 python-coveralls==2.7.0
 requests==2.9.1

--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -7,4 +7,6 @@ PyJWT==1.4.0
 PyYAML==3.12
 requests==2.9.1
 simplejson==3.10.0
+jsonpatch==1.16
+jsonpointer==2.0
 jsonschema


### PR DESCRIPTION
Problem: To have feature parity with the original OpenShift
Big-IP router, we need to allow the user the ability to create
resources and then have the controller manage them.
    
Solution: CCCL will keep track of changes made by the CCs to
whitelisted resources.  These changes need to be backed out 
when new changes are requested by CC for the resource.
