### PR TITLE
Pin f5-icontrol-rest package

### DIFF
--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -1,4 +1,5 @@
 # F5-CCCL Install Requirements
+f5-icontrol-rest==1.3.4
 f5-sdk==3.0.3
 ipaddress==1.0.17
 netaddr==0.7.19


### PR DESCRIPTION
Problem: The f5-common-python which is pinned by the CCCL, does not
pin the f5-icontrol-rest package this it imports. This introduces
the possibility to pull in unwanted changes and makes reproducible
builds impossible.

Solution: The temporary solution is to have the CCCL pin the
f5-icontrol-rest to a known good version.