### PR TITLE
Updated CCCL schema for snat config.

### DIFF
--- a/f5_cccl/schemas/cccl-ltm-api-schema.yml
+++ b/f5_cccl/schemas/cccl-ltm-api-schema.yml
@@ -94,6 +94,7 @@ definitions:
         enum:
           - "snat"
           - "automap"
+          - "none"
       pool:
         type: "string"
         desctiption: >
@@ -474,7 +475,7 @@ definitions:
         definition: >
           Specifies the IP address for the pool member. This is of the
           form <ip_address>[%<route_domain>]
-      port: 
+      port:
         definition: "Specifies the service port for the pool member."
         $ref: "#/definitions/portType"
       priorityGroup:
@@ -776,9 +777,9 @@ definitions:
           selective and intelligent source address translation. The default is automap.
           Supported values are:
             automap
-            snatpool
-            None
-          If snatpool is set, then the snatpool configuration item must be defined.
+            snat
+            none
+          If snat is set, then the pool configuration item must be defined.
         $ref: "#/definitions/snatConfigType"
 
       vlansEnabled:


### PR DESCRIPTION
Problem:
 Current schema does not allow for source address translation of none to
 be configured on virtual servers. Also some of the documentation does
 not match the schema definitions.

Solution:
 Allow for none type source address translation to be configured and
 correct documentation.