### PR TITLE
Added source address translation validation tests.

### DIFF
--- a/f5_cccl/schemas/cccl-ltm-api-schema.yml
+++ b/f5_cccl/schemas/cccl-ltm-api-schema.yml
@@ -97,7 +97,7 @@ definitions:
           - "none"
       pool:
         type: "string"
-        desctiption: >
+        description: >
           Full path to snat pool, (e.g. /Common/my_snatpool)
     required:
       - "type"


### PR DESCRIPTION
Problem:
 Both the marathon and k8s controllers pass labels/annotations to CCCL
 that are not validated until the CCCL layer for source address
 translation configurations of virtual servers. This behavior has not
 yet been verified through unit tests against CCCL.

Solution:
 Add unit tests to CCCL to validate source address translation
 configuration on virtual servers.