### PR TITLE
Added CCCL support for url-rewrite app-root annotations.

### DIFF
--- a/f5_cccl/resource/ltm/policy/action.py
+++ b/f5_cccl/resource/ltm/policy/action.py
@@ -41,6 +41,11 @@ class Action(Resource):
         setVariable=False,
         tcl=False,
         tmName=None,
+        httpHost=False,
+        httpUri=False,
+        path=None,
+        replace=False,
+        value=None,
     )
 
     def __init__(self, name, data):
@@ -87,10 +92,27 @@ class Action(Resource):
             self._data['tmName'] = data.get('tmName', None)
             self._data['expression'] = data.get('expression', None)
             self._data['tcl'] = True
+        # Is this a replace URI host action?
+        elif data.get('replace', False) and data.get('httpHost', False):
+            self._data['replace'] = True
+            self._data['httpHost'] = True
+            self._data['value'] = data.get('value', None)
+        # Is this a replace URI path action?
+        elif data.get('replace', False) and data.get('httpUri', False) and \
+                data.get('path', False):
+            self._data['replace'] = True
+            self._data['httpUri'] = True
+            self._data['path'] = True
+            self._data['value'] = data.get('value', None)
+        # Is this a replace URI action?
+        elif data.get('replace', False) and data.get('httpUri', False):
+            self._data['replace'] = True
+            self._data['httpUri'] = True
+            self._data['value'] = data.get('value', None)
         else:
             # Only forward, redirect and setVariable are supported.
             raise ValueError("Unsupported action, must be one of forward, "
-                             "redirect, setVariable or reset.")
+                             "redirect, setVariable, replace, or reset.")
 
     def __eq__(self, other):
         """Check the equality of the two objects.

--- a/f5_cccl/resource/ltm/policy/condition.py
+++ b/f5_cccl/resource/ltm/policy/condition.py
@@ -82,9 +82,12 @@ class Condition(Resource):
                 condition_map['index'] = data.get('index', 1)
             elif data.get('extension', False):
                 condition_map['extension'] = True
+            elif data.get('host', False):
+                condition_map['host'] = True
             else:
-                raise ValueError("must specify one of path, pathSegment, or "
-                                 "extension for HTTP URI matching condition")
+                raise ValueError("must specify one of host path, pathSegment, "
+                                 "or extension for HTTP URI matching "
+                                 "condition")
 
         # Does this rule match an HTTP header?
         elif data.get('httpHeader', False):

--- a/f5_cccl/schemas/cccl-ltm-api-schema.yml
+++ b/f5_cccl/schemas/cccl-ltm-api-schema.yml
@@ -259,6 +259,11 @@ definitions:
         - "replace"
         - "value"
         - "request"
+      - required:
+        - "httpHost"
+        - "replace"
+        - "value"
+        - "request"
 
   l7ConditionType:
     type: "object"

--- a/f5_cccl/schemas/cccl-ltm-api-schema.yml
+++ b/f5_cccl/schemas/cccl-ltm-api-schema.yml
@@ -254,20 +254,11 @@ definitions:
         - "setVariable"
       - required:
         - "httpHost"
-        - "replace"
-        - "request"
-        - "value"
-      - required:
         - "httpUri"
         - "path"
         - "replace"
-        - "request"
         - "value"
-      - required:
-        - "httpUri"
-        - "replace"
         - "request"
-        - "value"
 
   l7ConditionType:
     type: "object"

--- a/f5_cccl/schemas/cccl-ltm-api-schema.yml
+++ b/f5_cccl/schemas/cccl-ltm-api-schema.yml
@@ -168,7 +168,7 @@ definitions:
   l7RuleActionType:
     type: "object"
     description: |
-      Defines an L7 Policy action. The only supported actions are forward and redirect.
+      Defines an L7 Policy action. The only supported actions are forward, redirect, and replace.
 
       The supported forwarding actions are forward to pool and reset(block).
       The supported redirect action is redirect to location (URI)
@@ -216,6 +216,21 @@ definitions:
       setVariable:
         type: "boolean"
         description: "Sets specified variable to value of expression in runtime environment"
+      httpHost:
+        type: "boolean"
+        description: "Set the HTTP host in runtime environment"
+      httpUri:
+        type: "boolean"
+        description: "Set the HTTP URI in runtime environment"
+      path:
+        type: "string"
+        description: "An HTTP request path"
+      replace:
+        type: "boolean"
+        description: "Sets the URL replacement value"
+      value:
+        type: "string"
+        description: "The URL replacement value"
 
     oneOf:
       - required:
@@ -237,6 +252,22 @@ definitions:
         - "tmName"
         - "tcl"
         - "setVariable"
+      - required:
+        - "httpHost"
+        - "replace"
+        - "request"
+        - "value"
+      - required:
+        - "httpUri"
+        - "path"
+        - "replace"
+        - "request"
+        - "value"
+      - required:
+        - "httpUri"
+        - "replace"
+        - "request"
+        - "value"
 
   l7ConditionType:
     type: "object"
@@ -355,6 +386,10 @@ definitions:
           - "httpCookie"
           - "values"
           - "tmName"
+      - required:
+          - "httpUri"
+          - "host"
+          - "values"
 
   l7PolicyType:
     id: "#/definitions/l7PolicyType"


### PR DESCRIPTION
Problem:
 Current CCCL implementation did not support certain actions and
 conditions that were needed for url-rewrite and app-root annotations
 for the k8s-bigip-ctlr.

Solution:
 Add support for these annotations in CCCL schema and implementations.