### PR TITLE
Whitelisted resources must prevent dependent resources from being del…

### DIFF
--- a/f5_cccl/resource/ltm/pool.py
+++ b/f5_cccl/resource/ltm/pool.py
@@ -80,15 +80,7 @@ class Pool(Resource):
         return True
 
     def _monitors_equal(self, other):
-        self_monitor_list = sorted(
-            [m.rstrip() for m in self._data['monitor'].split(" and ")]
-        )
-
-        other_monitor_list = sorted(
-            [m.rstrip() for m in other.data['monitor'].split(" and ")]
-        )
-
-        return self_monitor_list == other_monitor_list
+        return self.monitors() == other.monitors()
 
     def __hash__(self):  # pylint: disable=useless-super-delegation
         return super(Pool, self).__hash__()
@@ -98,6 +90,13 @@ class Pool(Resource):
 
     def _uri_path(self, bigip):
         return bigip.tm.ltm.pools.pool
+
+    def monitors(self):
+        """Return list of configured monitors"""
+        self_monitor_list = sorted(
+            [m.rstrip() for m in self._data['monitor'].split(" and ")]
+        )
+        return self_monitor_list
 
 
 class ApiPool(Pool):


### PR DESCRIPTION
…eted

Problem:  When a resource is white-listed (like a virtual server), it
will reference other resources like policies, profiles, etc.  No attempts
should be made to clean up these resources.

Solution: Make a pass through the whitelisted resources (virtuals and
pools) and see what dependent resources they use.  These resources are
removed from the delete lists for the resource type.

Fixes: #221