### PR TITLE
Prune profiles of whitelisted virtuals

### DIFF
--- a/f5_cccl/api.py
+++ b/f5_cccl/api.py
@@ -73,6 +73,13 @@ class F5CloudServiceManager(object):
                                                partition,
                                                schema_path)
 
+    def get_proxy(self):
+        """Return the BigIP proxy"""
+
+        # This is only needed until delete_unused_ssl_profiles is properly
+        # integrated into apply_ltm_config
+        return self._bigip_proxy
+
     def apply_ltm_config(self, services):
         """Apply LTM service configurations to the BIG-IP partition.
 


### PR DESCRIPTION
Problem:  The handling of unused profiles is done out-of-band.
That is, outside of the call apply_ltm_config().  This results
in REST errors when CCCL tries to remove profiles that are in
used by white-listed virtuals.

Solution: Similar to the handling in apply_ltm_config, a list of
profiles is create that are referenced from whitelisted virtuals.
When the request to delete unused profiles is made (based on the
config), this list is consulted and if a match is found, the
request to delete is ignored.

Also removed a duplicate function.

Fixes: #220, #223