### PR TITLE
Unit tests for url-rewrite policies

### DIFF
--- a/f5_cccl/resource/ltm/policy/action.py
+++ b/f5_cccl/resource/ltm/policy/action.py
@@ -102,7 +102,7 @@ class Action(Resource):
                 data.get('path', False):
             self._data['replace'] = True
             self._data['httpUri'] = True
-            self._data['path'] = True
+            self._data['path'] = data.get('path', None)
             self._data['value'] = data.get('value', None)
         # Is this a replace URI action?
         elif data.get('replace', False) and data.get('httpUri', False):

--- a/f5_cccl/resource/ltm/policy/test/test_action.py
+++ b/f5_cccl/resource/ltm/policy/test/test_action.py
@@ -54,6 +54,20 @@ actions = {
         "forward": True,
         "virtual": "/Test/my_virtual"
     },
+    'rewrite_host': {
+        "httpHost": True,
+        "replace": True,
+        "request": True,
+        "value": "bar.com"
+    },
+    'rewrite_uri': {
+        "httpHost": False,
+        "httpUri": True,
+        "path": "/foo",
+        "replace": True,
+        "request": True,
+        "value": "/bar"
+    },
     'invalid_action': {
         "request": False,
         "forward": False,
@@ -127,6 +141,46 @@ def test_create_set_variable_action():
     assert not data.get('location')
     assert not data.get('reset')
     assert not data.get('forward')
+
+
+def test_create_rewrite_uri_action():
+    name="0"
+    action = Action(name, actions['rewrite_uri'])
+    data = action.data
+
+    assert action.name == "0"
+    assert not action.partition
+    assert data.get('httpUri')
+    assert data.get('request')
+    assert data.get('replace')
+    assert data.get('path') == '/foo'
+    assert data.get('value') == '/bar'
+    assert not data.get('httpHost')
+    assert not data.get('forward')
+    assert not data.get('reset')
+    assert not data.get('pool')
+    assert not data.get('redirect')
+    assert not data.get('location')
+
+
+def test_create_rewrite_host_action():
+    name="0"
+    action = Action(name, actions['rewrite_host'])
+    data = action.data
+
+    assert action.name == "0"
+    assert not action.partition
+    assert data.get('httpHost')
+    assert data.get('request')
+    assert data.get('replace')
+    assert data.get('value') == 'bar.com'
+    assert not data.get('httpUri')
+    assert not data.get('path')
+    assert not data.get('forward')
+    assert not data.get('reset')
+    assert not data.get('pool')
+    assert not data.get('redirect')
+    assert not data.get('location')
 
 
 def test_create_invalid_action():

--- a/f5_cccl/resource/ltm/policy/test/test_condition.py
+++ b/f5_cccl/resource/ltm/policy/test/test_condition.py
@@ -26,6 +26,12 @@ conditions = {
         'equals': True,
         'values': ["www.my-site.com", "www.your-site.com"],
     },
+    'http_uri': {
+        'httpUri': True,
+        'host': True,
+        'equals': True,
+        'values': ["bar.com", "foo.com"],
+    },
     'http_uri_path': {
         'httpUri': True,
         'path': True,
@@ -96,6 +102,35 @@ def test_create_http_host_match():
     assert not data.get('contains')
 
     assert 'httpUri' not in data
+    assert 'httpCookie' not in data
+    assert 'httpHeader' not in data
+
+    assert not data.get('index')
+    assert not data.get('path')
+    assert not data.get('pathSegment')
+    assert not data.get('extension')
+    assert not data.get('httpCookie')
+    assert not data.get('httpHeader')
+    assert not data.get('tmName')
+
+
+def test_create_http_uri_match():
+    name="0"
+    condition = Condition(name, conditions['http_uri'])
+    data = condition.data
+
+    assert condition.name == "0"
+    assert not condition.partition
+    assert data.get('httpUri')
+    assert data.get('host')
+    assert data.get('equals')
+    assert data.get('values') == ["bar.com", "foo.com"]
+
+    assert not data.get('startsWith')
+    assert not data.get('endsWith')
+    assert not data.get('contains')
+
+    assert 'httpHost' not in data
     assert 'httpCookie' not in data
     assert 'httpHeader' not in data
 

--- a/f5_cccl/schemas/tests/ltm_service.json
+++ b/f5_cccl/schemas/tests/ltm_service.json
@@ -83,7 +83,34 @@
 	"policies": [
 	  {"name": "wrapper_policy", "partition": "test"}
 	]
-  }],
+  },
+  {
+    "destination": "/test/172.16.3.39:80",
+    "enabled": true,
+    "ipProtocol": "tcp",
+    "name": "ingress_172-16-3-39_80",
+    "policies": [
+       {
+         "name": "url-rewrite-app-root-policy",
+         "partition": "test"
+       }
+    ],
+    "pool": "/test/ingress_default_svc",
+    "profiles": [{
+      "context": "all",
+      "name": "http",
+      "partition": "Common"
+    },
+    {
+      "context": "all",
+      "name": "tcp",
+      "partition": "Common"
+    }],
+    "sourceAddressTranslation": {
+      "type": "automap"
+    }
+  }
+],
   "pools": [
     { "name": "pool2",
       "members": [
@@ -108,6 +135,68 @@
 	  "type": "tcp" }
   ],
   "l7Policies": [{
+    "controls": [
+      "forwarding"
+    ],
+    "legacy": true,
+    "name": "url-rewrite-app-root-policy",
+    "requires": [
+      "http"
+    ],
+    "rules": [{
+      "actions": [{
+        "httpHost": false,
+        "httpReply": true,
+        "location": "/bar",
+        "name": "0",
+        "redirect": true,
+        "request": true,
+        "value": ""
+    }],
+      "conditions": [{
+        "caseInsensitive": true,
+        "equals": true,
+        "external": true,
+        "httpUri": true,
+        "name": "0",
+        "path": true,
+        "present": true,
+        "remote": true,
+        "request": true,
+        "values": [
+          "/"
+        ]
+    }],
+      "name": "app-root-redirect-rule-969c5745-5770-4166-90c6-4dede91dd285"
+    },
+    {
+      "actions": [{
+        "forward": true,
+        "httpHost": false,
+        "name": "0",
+        "pool": "/test/ingress_default_svc",
+        "request": true,
+        "value": ""
+      }],
+      "conditions": [{
+        "caseInsensitive": true,
+        "equals": true,
+        "external": true,
+        "httpUri": true,
+        "name": "0",
+        "path": true,
+        "present": true,
+        "remote": true,
+        "request": true,
+        "values": [
+            "/bar"
+        ]
+    }],
+      "name": "app-root-forward-rule-945cf6d8-5cf6-4c82-a3f0-99822b4b0141"
+    }],
+      "strategy": "/Common/first-match"
+    },
+    {
     "name": "test_wrapper_policy",
 	"strategy": "/Common/first-match",
 	"rules": [

--- a/f5_cccl/service/test/test_config_reader.py
+++ b/f5_cccl/service/test/test_config_reader.py
@@ -52,13 +52,13 @@ class TestServiceConfigReader:
         config = reader.read_ltm_config(self.ltm_service, 0,
                                         'marathon-bigip-ctlr-v1.2.1')
 
-        assert len(config.get('virtuals')) == 1
+        assert len(config.get('virtuals')) == 2
         assert len(config.get('pools')) == 1
         assert len(config.get('http_monitors')) == 1
         assert len(config.get('https_monitors')) == 1
         assert len(config.get('icmp_monitors')) == 1
         assert len(config.get('tcp_monitors')) == 1
-        assert len(config.get('l7policies')) == 1
+        assert len(config.get('l7policies')) == 2
         assert len(config.get('iapps')) == 1
 
         config = reader.read_net_config(self.net_service, 0)

--- a/f5_cccl/service/test/test_service_manager.py
+++ b/f5_cccl/service/test/test_service_manager.py
@@ -202,13 +202,14 @@ class TestServiceConfigDeployer:
 
     def test_virtual_servers(self, ltm_service_manager):
         """Test create/update/delete of Virtual Servers."""
-        # Should create one Virtual Server 
+        # Should create two Virtual Servers
         #  and ignore Big-IP virtuals not in the partition (/Common/virtual1)
         # or have the cccl-whitelist metadata set (test/virtual3)
         objs = self.get_created_ltm_objects(ltm_service_manager, VirtualServer)
-        assert 1 == len(objs)
-        assert objs[0].name == 'vs1'
+        assert 2 == len(objs)
+        assert sorted([o.name for o in objs]) == ['ingress_172-16-3-39_80', 'vs1']
         assert objs[0].data['metadata'][0]['value'] == TEST_USER_AGENT
+        assert objs[1].data['metadata'][0]['value'] == TEST_USER_AGENT
 
         # Should update one Virtual Server
         self.ltm_service['virtualServers'][0]['name'] = 'virtual2'
@@ -265,10 +266,10 @@ class TestServiceConfigDeployer:
 
     def test_policies(self, ltm_service_manager):
         """Test create/update/delete of L7 Policies."""
-        # Should create one Policy 
+        # Should create two Policies
         objs = self.get_created_ltm_objects(ltm_service_manager, Policy)
-        assert 1 == len(objs)
-        assert objs[0].name == 'test_wrapper_policy'
+        assert 2 == len(objs)
+        assert sorted([o.name for o in objs]) == ['test_wrapper_policy', 'url-rewrite-app-root-policy']
 
         # Should update one Policy
         self.ltm_service['l7Policies'][0]['name'] = 'wrapper_policy'


### PR DESCRIPTION
Added unit tests for new policy-rule actions and conditions that
support url host and path rewrites.