### PR TITLE
Add actions for tcp addresses and various fixes

### DIFF
--- a/f5_cccl/resource/ltm/policy/action.py
+++ b/f5_cccl/resource/ltm/policy/action.py
@@ -46,6 +46,8 @@ class Action(Resource):
         path=None,
         replace=False,
         value=None,
+        shutdown=True,
+        select=True,
     )
 
     def __init__(self, name, data):
@@ -69,14 +71,25 @@ class Action(Resource):
             # exclusive options.
             pool = data.get('pool', None)
             reset = data.get('reset', False)
+
+            # This allows you to specify an empty node. This is
+            # what Container Connector does.
+            select = data.get('select', False)
+
+            # This was added in 13.1.0
+            shutdown = data.get('shutdown', False)
             if pool:
                 self._data['pool'] = pool
             elif reset:
                 self._data['reset'] = reset
+            elif select:
+                self._data['select'] = select
+            elif shutdown:
+                self._data['shutdown'] = shutdown
             else:
                 raise ValueError(
-                    "Unsupported forward action, must be one of reset or "
-                    "forward to pool.")
+                    "Unsupported forward action, must be one of reset, "
+                    "forward to pool, select, or shutdown.")
         # Is this a redirect action?
         elif data.get('redirect', False):
             self._data['redirect'] = True

--- a/f5_cccl/schemas/cccl-ltm-api-schema.yml
+++ b/f5_cccl/schemas/cccl-ltm-api-schema.yml
@@ -231,8 +231,20 @@ definitions:
       value:
         type: "string"
         description: "The URL replacement value"
+      shutdown:
+        type: "boolean"
+        description: "Reset the connection. (since 13.1.0)"
+      select:
+        type: "boolean"
+        description: "Select location to forward to."
 
     oneOf:
+      - required:
+        - "forward"
+        - "select"
+      - required:
+        - "forward"
+        - "shutdown"
       - required:
         - "forward"
         - "request"

--- a/f5_cccl/schemas/tests/ltm_service.json
+++ b/f5_cccl/schemas/tests/ltm_service.json
@@ -1,292 +1,407 @@
 {
   "name": "test1",
-
-  "iapps": [{
-    "name": "MyAppService0",
-    "template": "/Common/f5.http",
-    "options": {"description": "This is a test iApp"},
-    "poolMemberTable": {
-      "name": "pool__members",
-      "columns": [
-        {"name": "addr", "kind": "IPAddress"},
-        {"name": "port", "kind": "Port"},
-        {"name": "connection_limit", "value": "0"}
-      ],
-      "members": [
-        {"address": "1.2.3.4", "port": 30001},
-        {"address": "1.2.3.4", "port": 30002},
-        {"address": "1.2.3.4", "port": 30003},
-        {"address": "1.2.3.4", "port": 30004},
-        {"address": "1.2.3.4", "port": 30005}
-      ]
-    },
-    "variables": {
-      "net__client_mode": "wan",
-      "net__server_mode": "lan",
-      "pool__addr": "10.10.1.100",
-      "pool__port": "80",
-      "pool__pool_to_use": "/#create_new#",
-      "pool__lb_method": "round-robin",
-      "pool__http": "/#create_new#",
-      "pool__mask": "255.255.255.255",
-      "pool__persist": "/#do_not_use#",
-      "monitor__monitor": "/#create_new#",
-      "monitor__uri": "/",
-      "monitor__frequency": "30",
-      "monitor__response": "none",
-      "ssl_encryption_questions__advanced": "yes",
-      "net__vlan_mode": "all",
-      "net__snat_type": "automap",
-      "client__tcp_wan_opt": "/#create_new#",
-      "client__standard_caching_with_wa": "/#create_new#",
-      "client__standard_caching_without_wa": "/#do_not_use#",
-      "server__tcp_lan_opt": "/#create_new#",
-      "server__oneconnect": "/#create_new#",
-      "server__ntlm": "/#do_not_use#"
+  "iapps": [
+    {
+      "name": "MyAppService0",
+      "template": "/Common/f5.http",
+      "options": {
+        "description": "This is a test iApp"
+      },
+      "poolMemberTable": {
+        "name": "pool__members",
+        "columns": [
+          {
+            "name": "addr",
+            "kind": "IPAddress"
+          },
+          {
+            "name": "port",
+            "kind": "Port"
+          },
+          {
+            "name": "connection_limit",
+            "value": "0"
+          }
+        ],
+        "members": [
+          {
+            "address": "1.2.3.4",
+            "port": 30001
+          },
+          {
+            "address": "1.2.3.4",
+            "port": 30002
+          },
+          {
+            "address": "1.2.3.4",
+            "port": 30003
+          },
+          {
+            "address": "1.2.3.4",
+            "port": 30004
+          },
+          {
+            "address": "1.2.3.4",
+            "port": 30005
+          }
+        ]
+      },
+      "variables": {
+        "net__client_mode": "wan",
+        "net__server_mode": "lan",
+        "pool__addr": "10.10.1.100",
+        "pool__port": "80",
+        "pool__pool_to_use": "/#create_new#",
+        "pool__lb_method": "round-robin",
+        "pool__http": "/#create_new#",
+        "pool__mask": "255.255.255.255",
+        "pool__persist": "/#do_not_use#",
+        "monitor__monitor": "/#create_new#",
+        "monitor__uri": "/",
+        "monitor__frequency": "30",
+        "monitor__response": "none",
+        "ssl_encryption_questions__advanced": "yes",
+        "net__vlan_mode": "all",
+        "net__snat_type": "automap",
+        "client__tcp_wan_opt": "/#create_new#",
+        "client__standard_caching_with_wa": "/#create_new#",
+        "client__standard_caching_without_wa": "/#do_not_use#",
+        "server__tcp_lan_opt": "/#create_new#",
+        "server__oneconnect": "/#create_new#",
+        "server__ntlm": "/#do_not_use#"
+      }
     }
-  }],
-  "virtualAddresses": [
-	{
-	  "name": "192.168.0.1%2",
-	  "autoDelete": "false",
-	  "enabled": "yes",
-	  "address": "192.168.0.1%2"
-	},
-	{
-	  "name": "MyVaddr",
-	  "autoDelete": "false",
-	  "enabled": "no",
-	  "address": "192.168.0.2"
-	}
   ],
-  "virtualServers": [{
-	"name": "vs1",
-	"destination": "/test/MyVaddr:80",
-	"pool": "/test/pool1",
-	"sourceAddress": "0.0.0.0/0",
-	"enabled": true,
-	"vlansEnabled": true,
-	"vlans": ["/test/vlan-100", "/Common/http-tunnel"],
-	"sourceAddressTranslation": {
-	  "type": "snat",
-	  "pool": "/test/snatpool1"
-	},
-	"profiles": [
-	  {"name": "tcp-lan-optimized", "partition": "Common", "context": "serverside"},
-	  {"name": "tcp-wan-optimized", "partition": "Common", "context": "clientside"},
-	  {"name": "http", "partition": "Common", "context": "all"},
-	  {"name": "clientssl", "partition": "Common", "context": "clientside"}
-	],
-	"iRules": [
-	  "/test/https_redirect"
-	],
-	"policies": [
-	  {"name": "wrapper_policy", "partition": "test"}
-	]
-  },
-  {
-    "destination": "/test/172.16.3.39:80",
-    "enabled": true,
-    "ipProtocol": "tcp",
-    "name": "ingress_172-16-3-39_80",
-    "policies": [
-       {
-         "name": "url-rewrite-app-root-policy",
-         "partition": "test"
-       }
-    ],
-    "pool": "/test/ingress_default_svc",
-    "profiles": [{
-      "context": "all",
-      "name": "http",
-      "partition": "Common"
+  "virtualAddresses": [
+    {
+      "name": "192.168.0.1%2",
+      "autoDelete": "false",
+      "enabled": "yes",
+      "address": "192.168.0.1%2"
     },
     {
-      "context": "all",
-      "name": "tcp",
-      "partition": "Common"
-    }],
-    "sourceAddressTranslation": {
-      "type": "automap"
+      "name": "MyVaddr",
+      "autoDelete": "false",
+      "enabled": "no",
+      "address": "192.168.0.2"
     }
-  }
-],
-  "pools": [
-    { "name": "pool2",
-      "members": [
-        {"address": "172.16.0.100%1", "port": 8080},
-        {"address": "172.16.0.101", "port": 8080}
+  ],
+  "virtualServers": [
+    {
+      "name": "vs1",
+      "destination": "/test/MyVaddr:80",
+      "pool": "/test/pool1",
+      "sourceAddress": "0.0.0.0/0",
+      "enabled": true,
+      "vlansEnabled": true,
+      "vlans": [
+        "/test/vlan-100",
+        "/Common/http-tunnel"
       ],
-      "monitors": ["/test/myhttp"]
+      "sourceAddressTranslation": {
+        "type": "snat",
+        "pool": "/test/snatpool1"
+      },
+      "profiles": [
+        {
+          "name": "tcp-lan-optimized",
+          "partition": "Common",
+          "context": "serverside"
+        },
+        {
+          "name": "tcp-wan-optimized",
+          "partition": "Common",
+          "context": "clientside"
+        },
+        {
+          "name": "http",
+          "partition": "Common",
+          "context": "all"
+        },
+        {
+          "name": "clientssl",
+          "partition": "Common",
+          "context": "clientside"
+        }
+      ],
+      "iRules": [
+        "/test/https_redirect"
+      ],
+      "policies": [
+        {
+          "name": "wrapper_policy",
+          "partition": "test"
+        }
+      ]
+    },
+    {
+      "destination": "/test/172.16.3.39:80",
+      "enabled": true,
+      "ipProtocol": "tcp",
+      "name": "ingress_172-16-3-39_80",
+      "policies": [
+        {
+          "name": "url-rewrite-app-root-policy",
+          "partition": "test"
+        }
+      ],
+      "pool": "/test/ingress_default_svc",
+      "profiles": [
+        {
+          "context": "all",
+          "name": "http",
+          "partition": "Common"
+        },
+        {
+          "context": "all",
+          "name": "tcp",
+          "partition": "Common"
+        }
+      ],
+      "sourceAddressTranslation": {
+        "type": "automap"
+      }
+    }
+  ],
+  "pools": [
+    {
+      "name": "pool2",
+      "members": [
+        {
+          "address": "172.16.0.100%1",
+          "port": 8080
+        },
+        {
+          "address": "172.16.0.101",
+          "port": 8080
+        }
+      ],
+      "monitors": [
+        "/test/myhttp"
+      ]
     }
   ],
   "monitors": [
-    { "name": "myhttp",
-	  "type": "http",
-	  "send": "GET /\r\n",
-	  "recv": "SERVER" },
-    { "name": "myhttps",
-	  "type": "https",
-	  "send": "GET /\r\n",
-	  "recv": "HTTPS-SERVER" },
-    { "name": "my_ping",
-	  "type": "icmp" },
-    { "name": "my_tcp",
-	  "type": "tcp" }
-  ],
-  "l7Policies": [{
-    "controls": [
-      "forwarding"
-    ],
-    "legacy": true,
-    "name": "url-rewrite-app-root-policy",
-    "requires": [
-      "http"
-    ],
-    "rules": [{
-      "actions": [{
-        "httpHost": false,
-        "httpReply": true,
-        "location": "/bar",
-        "name": "0",
-        "redirect": true,
-        "request": true,
-        "value": ""
-    }],
-      "conditions": [{
-        "caseInsensitive": true,
-        "equals": true,
-        "external": true,
-        "httpUri": true,
-        "name": "0",
-        "path": true,
-        "present": true,
-        "remote": true,
-        "request": true,
-        "values": [
-          "/"
-        ]
-    }],
-      "name": "app-root-redirect-rule-969c5745-5770-4166-90c6-4dede91dd285"
+    {
+      "name": "myhttp",
+      "type": "http",
+      "send": "GET /\r\n",
+      "recv": "SERVER"
     },
     {
-      "actions": [{
-        "forward": true,
-        "httpHost": false,
-        "name": "0",
-        "pool": "/test/ingress_default_svc",
-        "request": true,
-        "value": ""
-      }],
-      "conditions": [{
-        "caseInsensitive": true,
-        "equals": true,
-        "external": true,
-        "httpUri": true,
-        "name": "0",
-        "path": true,
-        "present": true,
-        "remote": true,
-        "request": true,
-        "values": [
-            "/bar"
-        ]
-    }],
-      "name": "app-root-forward-rule-945cf6d8-5cf6-4c82-a3f0-99822b4b0141"
-    }],
+      "name": "myhttps",
+      "type": "https",
+      "send": "GET /\r\n",
+      "recv": "HTTPS-SERVER"
+    },
+    {
+      "name": "my_ping",
+      "type": "icmp"
+    },
+    {
+      "name": "my_tcp",
+      "type": "tcp"
+    }
+  ],
+  "l7Policies": [
+    {
+      "controls": [
+        "forwarding"
+      ],
+      "legacy": true,
+      "name": "url-rewrite-app-root-policy",
+      "requires": [
+        "http"
+      ],
+      "rules": [
+        {
+          "actions": [
+            {
+              "httpHost": false,
+              "httpReply": true,
+              "location": "/bar",
+              "name": "0",
+              "redirect": true,
+              "request": true,
+              "value": ""
+            }
+          ],
+          "conditions": [
+            {
+              "caseInsensitive": true,
+              "equals": true,
+              "external": true,
+              "httpUri": true,
+              "name": "0",
+              "path": true,
+              "present": true,
+              "remote": true,
+              "request": true,
+              "values": [
+                "/"
+              ]
+            }
+          ],
+          "name": "app-root-redirect-rule-969c5745-5770-4166-90c6-4dede91dd285"
+        },
+        {
+          "actions": [
+            {
+              "forward": true,
+              "httpHost": false,
+              "name": "0",
+              "pool": "/test/ingress_default_svc",
+              "request": true,
+              "value": ""
+            }
+          ],
+          "conditions": [
+            {
+              "caseInsensitive": true,
+              "equals": true,
+              "external": true,
+              "httpUri": true,
+              "name": "0",
+              "path": true,
+              "present": true,
+              "remote": true,
+              "request": true,
+              "values": [
+                "/bar"
+              ]
+            }
+          ],
+          "name": "app-root-forward-rule-945cf6d8-5cf6-4c82-a3f0-99822b4b0141"
+        }
+      ],
       "strategy": "/Common/first-match"
     },
     {
-    "name": "test_wrapper_policy",
-	"strategy": "/Common/first-match",
-	"rules": [
-	  {
-		"conditions": [
-		  {
-			"httpHost": true,
-			"host": true,
-			"equals": true,
-			"values": ["http://www.mysite.com"]
-		  },
-		  {
-			"httpUri": true,
-			"pathSegment": true,
-			"equals": true,
-			"index": 2,
-			"values": ["articles"]
-		  }
-		],
-		"name": "rule1",
-		"actions": [
-		  {
-			"request": true,
-			"forward": true,
-			"reset": true
-		  }
-		]
-	  },
-	  {
-		"conditions": [
-		  {
-			"httpUri": true,
-			"path": true,
-			"not": true,
-			"equals": true,
-			"values": ["www.mysite.com"]
-		  }
-		],
-		"name": "rule2",
-		"actions": [
-		  {
-			"forward": true,
-			"request": true,
-			"pool": "/test/pool2"
-		  }
-		]
-	  },
-	  {
-		"conditions": [
-		  {
-			"httpHeader": true,
-			"caseSensitive": true,
-			"tmName": "X-Foo",
-			"not": true,
-			"startsWith": true,
-			"values": ["ignore"]
-		  }
-		],
-		"name": "rule3",
-		"actions": [
-		  {
-			"request": true,
-			"redirect": true,
-			"httpReply": true,
-			"location": "http://www.othersite.com"
-		  }
-		]
-	  },
-      {
-		"conditions": [
-		  {
-            "tcp": true,
-            "address": true,
-            "matches": true,
-            "external": true,
-            "values": ["10.10.10.10/32"]
-		  }
-		],
-		"name": "rule3",
-		"actions": [
-		  {
-			"request": true,
-			"redirect": true,
-			"httpReply": true,
-			"location": "http://www.othersite.com"
-		  }
-		]
-	  }
-	]
-  }],
+      "name": "test_wrapper_policy",
+      "strategy": "/Common/first-match",
+      "rules": [
+        {
+          "conditions": [
+            {
+              "httpHost": true,
+              "host": true,
+              "equals": true,
+              "values": [
+                "http://www.mysite.com"
+              ]
+            },
+            {
+              "httpUri": true,
+              "pathSegment": true,
+              "equals": true,
+              "index": 2,
+              "values": [
+                "articles"
+              ]
+            }
+          ],
+          "name": "rule1",
+          "actions": [
+            {
+              "request": true,
+              "forward": true,
+              "reset": true
+            }
+          ]
+        },
+        {
+          "conditions": [
+            {
+              "httpUri": true,
+              "path": true,
+              "not": true,
+              "equals": true,
+              "values": [
+                "www.mysite.com"
+              ]
+            }
+          ],
+          "name": "rule2",
+          "actions": [
+            {
+              "forward": true,
+              "request": true,
+              "pool": "/test/pool2"
+            }
+          ]
+        },
+        {
+          "conditions": [
+            {
+              "httpHeader": true,
+              "caseSensitive": true,
+              "tmName": "X-Foo",
+              "not": true,
+              "startsWith": true,
+              "values": [
+                "ignore"
+              ]
+            }
+          ],
+          "name": "rule3",
+          "actions": [
+            {
+              "request": true,
+              "redirect": true,
+              "httpReply": true,
+              "location": "http://www.othersite.com"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "test_address_policy",
+      "strategy": "/Common/first-match",
+      "rules": [
+        {
+          "conditions": [
+            {
+              "tcp": true,
+              "address": true,
+              "matches": true,
+              "external": true,
+              "values": [
+                "10.10.10.10/32"
+              ]
+            }
+          ],
+          "name": "rule1",
+          "actions": [
+            {
+              "forward": true,
+              "select": true
+            }
+          ]
+        },
+        {
+          "conditions": [
+            {
+              "tcp": true,
+              "address": true,
+              "matches": true,
+              "external": true,
+              "values": [
+                "20.20.20.20/32"
+              ]
+            }
+          ],
+          "name": "rule2",
+          "actions": [
+            {
+              "forward": true,
+              "shutdown": true
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "iRules": [
     {
       "name": "https_redirect",

--- a/f5_cccl/schemas/tests/test_policy_schema_01.json
+++ b/f5_cccl/schemas/tests/test_policy_schema_01.json
@@ -1,0 +1,51 @@
+{
+  "name": "test1",
+  "l7Policies": [
+    {
+      "name": "test_address_policy",
+      "strategy": "/Common/first-match",
+      "rules": [
+        {
+          "conditions": [
+            {
+              "tcp": true,
+              "address": true,
+              "matches": true,
+              "external": true,
+              "values": [
+                "10.10.10.10/32"
+              ]
+            }
+          ],
+          "name": "rule1",
+          "actions": [
+            {
+              "forward": true,
+              "select": true
+            }
+          ]
+        },
+        {
+          "conditions": [
+            {
+              "tcp": true,
+              "address": true,
+              "matches": true,
+              "external": true,
+              "values": [
+                "20.20.20.20/32"
+              ]
+            }
+          ],
+          "name": "rule2",
+          "actions": [
+            {
+              "forward": true,
+              "select": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/f5_cccl/service/test/test_config_reader.py
+++ b/f5_cccl/service/test/test_config_reader.py
@@ -58,7 +58,7 @@ class TestServiceConfigReader:
         assert len(config.get('https_monitors')) == 1
         assert len(config.get('icmp_monitors')) == 1
         assert len(config.get('tcp_monitors')) == 1
-        assert len(config.get('l7policies')) == 2
+        assert len(config.get('l7policies')) == 3
         assert len(config.get('iapps')) == 1
 
         config = reader.read_net_config(self.net_service, 0)

--- a/f5_cccl/service/test/test_service_manager.py
+++ b/f5_cccl/service/test/test_service_manager.py
@@ -19,11 +19,11 @@ import pickle
 import pytest
 from f5_cccl.test.conftest import bigip_proxy
 
-from f5_cccl.resource.ltm.app_service import ApplicationService 
-from f5_cccl.resource.ltm.virtual import VirtualServer 
-from f5_cccl.resource.ltm.pool import Pool 
-from f5_cccl.resource.ltm.monitor.http_monitor import HTTPMonitor 
-from f5_cccl.resource.ltm.policy.policy import Policy 
+from f5_cccl.resource.ltm.app_service import ApplicationService
+from f5_cccl.resource.ltm.virtual import VirtualServer
+from f5_cccl.resource.ltm.pool import Pool
+from f5_cccl.resource.ltm.monitor.http_monitor import HTTPMonitor
+from f5_cccl.resource.ltm.policy.policy import Policy
 from f5_cccl.resource.ltm.internal_data_group import InternalDataGroup
 from f5_cccl.resource.ltm.irule import IRule
 from f5_cccl.resource.net.arp import Arp
@@ -226,7 +226,7 @@ class TestServiceConfigDeployer:
 
     def test_pools(self, ltm_service_manager):
         """Test create/update/delete of Pools."""
-        # Should create one Pool 
+        # Should create one Pool
         objs = self.get_created_ltm_objects(ltm_service_manager, Pool)
         assert 1 == len(objs)
         assert objs[0].name == 'pool2'
@@ -247,7 +247,7 @@ class TestServiceConfigDeployer:
 
     def test_monitors(self, ltm_service_manager):
         """Test create/update/delete of Health Monitors."""
-        # Should create one Monitor 
+        # Should create one Monitor
         objs = self.get_created_ltm_objects(ltm_service_manager, HTTPMonitor)
         assert 1 == len(objs)
         assert objs[0].name == 'myhttp'
@@ -259,7 +259,7 @@ class TestServiceConfigDeployer:
         assert objs[0].name == 'mon_http'
 
         # Should delete one Monitor
-        self.ltm_service['monitors'] = [] 
+        self.ltm_service['monitors'] = []
         objs = self.get_deleted_ltm_objects(ltm_service_manager, HTTPMonitor)
         assert 1 == len(objs)
         assert 'mon_http' == objs[0].name
@@ -268,8 +268,11 @@ class TestServiceConfigDeployer:
         """Test create/update/delete of L7 Policies."""
         # Should create two Policies
         objs = self.get_created_ltm_objects(ltm_service_manager, Policy)
-        assert 2 == len(objs)
-        assert sorted([o.name for o in objs]) == ['test_wrapper_policy', 'url-rewrite-app-root-policy']
+        assert 3 == len(objs)
+        assert sorted([o.name for o in objs]) == [
+            'test_address_policy', 'test_wrapper_policy',
+            'url-rewrite-app-root-policy'
+        ]
 
         # Should update one Policy
         self.ltm_service['l7Policies'][0]['name'] = 'wrapper_policy'
@@ -278,14 +281,14 @@ class TestServiceConfigDeployer:
         assert objs[0].name == 'wrapper_policy'
 
         # Should delete one Policy
-        self.ltm_service['l7Policies'] = [] 
+        self.ltm_service['l7Policies'] = []
         objs = self.get_deleted_ltm_objects(ltm_service_manager, Policy)
         assert 1 == len(objs)
         assert 'wrapper_policy' == objs[0].name
 
     def test_internal_data_groups(self, ltm_service_manager):
         """Test create/update/delete of Internal Data Groups."""
-        # Should create one Data Group 
+        # Should create one Data Group
         objs = self.get_created_ltm_objects(ltm_service_manager, InternalDataGroup)
         assert 1 == len(objs)
         assert objs[0].name == 'test-dgs'
@@ -304,7 +307,7 @@ class TestServiceConfigDeployer:
 
     def test_irules(self, ltm_service_manager):
         """Test create/update/delete of iRules."""
-        # Should create one iRule 
+        # Should create one iRule
         objs = self.get_created_ltm_objects(ltm_service_manager, IRule)
         assert 1 == len(objs)
         assert objs[0].name == 'https_redirect'
@@ -318,7 +321,7 @@ class TestServiceConfigDeployer:
         assert objs[0].data['metadata'][0]['value'] == TEST_USER_AGENT
 
         # Should delete one iRule
-        self.ltm_service['iRules'] = [] 
+        self.ltm_service['iRules'] = []
         objs = self.get_deleted_ltm_objects(ltm_service_manager, IRule)
         assert 1 == len(objs)
         assert 'https_redirector' == objs[0].name

--- a/test/f5_cccl/conftest.py
+++ b/test/f5_cccl/conftest.py
@@ -35,6 +35,7 @@ def _wrap_instrument(f, counters, name):
         return f(*args, **kwargs)
     return instrumented
 
+
 def instrument_bigip(mgmt_root):
     icr = mgmt_root.__dict__['_meta_data']['icr_session']
     counters = {}

--- a/test/f5_cccl/perf/test_perf.py
+++ b/test/f5_cccl/perf/test_perf.py
@@ -23,6 +23,8 @@ from pprint import pprint
 requests.packages.urllib3.disable_warnings()
 
 req_symbols = ['bigip_mgmt_ip', 'bigip_username', 'bigip_password', 'bigip_port']
+
+
 def missing_bigip_symbols():
     for sym in req_symbols:
         if not hasattr(pytest.symbols, sym):
@@ -97,19 +99,25 @@ testdata = [
 @pytest.mark.benchmark(group="apply-new")
 def test_apply_new(partition, cccl, bigip_rest_counters, benchmark, nv, nm):
     cfg = _make_svc_config(partition, num_virtuals=nv, num_members=nm)
+
     def setup():
         cccl.apply_ltm_config({})
-    def apply():
+
+    def apply_cfg():
         cccl.apply_ltm_config(cfg)
-    benchmark.pedantic(apply, setup=setup, rounds=2, iterations=1)
+
+    benchmark.pedantic(apply_cfg, setup=setup, rounds=2, iterations=1)
     pprint(bigip_rest_counters)
+
 
 @pytest.mark.parametrize("nv,nm", testdata)
 @pytest.mark.benchmark(group="apply-no-change")
 def test_apply_no_change(partition, cccl, bigip_rest_counters, benchmark, nv, nm):
     cfg = _make_svc_config(partition, num_virtuals=nv, num_members=nm)
-    def apply():
+
+    def apply_cfg():
         cccl.apply_ltm_config(cfg)
-    apply()
-    benchmark.pedantic(apply, rounds=2, iterations=1)
+
+    apply_cfg()
+    benchmark.pedantic(apply_cfg, rounds=2, iterations=1)
     pprint(bigip_rest_counters)

--- a/test/f5_cccl/resource/ltm/policy/test_policy.py
+++ b/test/f5_cccl/resource/ltm/policy/test_policy.py
@@ -38,26 +38,26 @@ requests.packages.urllib3.disable_warnings()
 
 actions = {
     'redirect': {
-	"request": True,
-	"redirect": True,
-	"location": "http://boulder-dev.f5.com",
-	"httpReply": True
+        "request": True,
+        "redirect": True,
+        "location": "http://boulder-dev.f5.com",
+        "httpReply": True
     },
     'redirect_http_https': {
-	"request": True,
-	"redirect": True,
-	"location": "tcl:https://[getfield [HTTP::host] : 1][HTTP::uri]",
-	"httpReply": True
+        "request": True,
+        "redirect": True,
+        "location": "tcl:https://[getfield [HTTP::host] : 1][HTTP::uri]",
+        "httpReply": True
     },
     'pool_forward': {
-	"request": True,
-	"forward": True,
-	"pool": "/Test1/pool1"
+        "request": True,
+        "forward": True,
+        "pool": "/Test1/pool1"
     },
     'reset': {
-	"request": True,
-	"forward": True,
-	"reset": True
+        "request": True,
+        "forward": True,
+        "reset": True
     },
     'invalid_action': {
         "request": False,
@@ -66,6 +66,10 @@ actions = {
         "location": None,
         "reset": False,
         "redirect": False
+    },
+    'select_forward': {
+        "forward": True,
+        "select": True
     }
 }
 
@@ -341,10 +345,10 @@ class TestPolicy(object):
         assert icr_policy
 
         for i in range(5):
-            test_rule = {
-                'actions': [],
-                'conditions': []
-            }
+            test_rule = dict(
+                actions=[],
+                conditions=[]
+            )
             test_rule['name'] = "rule_{}".format(i)
 
             policy_data['rules'].append(test_rule)

--- a/test/f5_cccl/service/test_manager.py
+++ b/test/f5_cccl/service/test_manager.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# Copyright (c) 2017,2018, F5 Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import pickle
+import pytest
+
+from f5_cccl.bigip import BigIPProxy
+from f5_cccl.resource.ltm.app_service import ApplicationService
+from f5_cccl.resource.ltm.virtual import VirtualServer
+from f5_cccl.resource.ltm.pool import Pool
+from f5_cccl.resource.ltm.monitor.http_monitor import HTTPMonitor
+from f5_cccl.resource.ltm.policy.policy import Policy
+from f5_cccl.resource.ltm.internal_data_group import InternalDataGroup
+from f5_cccl.resource.ltm.irule import IRule
+from f5_cccl.resource.net.arp import Arp
+from f5_cccl.resource.net.fdb.tunnel import FDBTunnel
+
+from f5_cccl.service.manager import ServiceConfigDeployer
+from f5_cccl.service.manager import ServiceManager
+from f5_cccl.service.config_reader import ServiceConfigReader
+
+from icontrol.exceptions import iControlUnexpectedHTTPError
+
+from mock import MagicMock
+from mock import Mock
+from mock import patch
+
+import logging
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
+
+TEST_USER_AGENT='k8s-bigip-ctlr-v1.4.0'
+
+
+req_symbols = ['bigip_mgmt_ip', 'bigip_username', 'bigip_password', 'bigip_port']
+
+
+def missing_bigip_symbols():
+    for sym in req_symbols:
+        if not hasattr(pytest.symbols, sym):
+            return True
+    return False
+
+
+pytestmark = pytest.mark.skipif(missing_bigip_symbols(),
+                                reason="Need symbols pointing at a real bigip.")
+
+
+@pytest.fixture
+def bigip_proxy(bigip, partition):
+    yield BigIPProxy(bigip, partition)
+
+
+@pytest.fixture
+def ltm_service_manager(bigip_proxy, partition):
+    schema = 'f5_cccl/schemas/cccl-ltm-api-schema.yml'
+    service_mgr = ServiceManager(
+        bigip_proxy,
+        partition,
+        schema
+    )
+    return service_mgr
+
+
+class TestServiceConfigDeployer:
+
+    def _get_policy_from_bigip(self, name, bigip, partition):
+        try:
+            icr_policy = bigip.tm.ltm.policys.policy.load(
+                name=name, partition=partition,
+                requests_params={'params': "expandSubcollections=true"})
+            code = 200
+        except iControlUnexpectedHTTPError as err:
+            icr_policy = None
+            code = err.response.status_code
+
+        return icr_policy, code
+
+    def test_deploy_ltm(self, bigip, partition, ltm_service_manager):
+        ltm_svcfile = 'f5_cccl/schemas/tests/test_policy_schema_01.json'
+        with open(ltm_svcfile, 'r') as fp:
+            test_service1 = json.loads(fp.read())
+
+        policy1 = test_service1['l7Policies'][0]['name']
+        tasks_remaining = ltm_service_manager.apply_ltm_config(
+            test_service1, TEST_USER_AGENT
+        )
+        assert 0 == tasks_remaining
+
+        # Get the policy from the bigip.
+        (icr_policy, code) = self._get_policy_from_bigip(
+            policy1, bigip, partition
+        )
+
+        # Assert object exists and test attributes.
+        assert icr_policy
+        assert icr_policy.raw['name'] == policy1
+
+        tasks_remaining = ltm_service_manager.apply_ltm_config(
+            {}, TEST_USER_AGENT
+        )
+        assert 0 == tasks_remaining


### PR DESCRIPTION
Adds actions to support tcp actions (select and shutdown). And
additionally adds functional tests for managers, formatting fixes
throughout the code, and new schema examples to test tcp address
configs.