### PR TITLE
Fix for mac address update in ARP

### DIFF
--- a/f5_cccl/resource/resource.py
+++ b/f5_cccl/resource/resource.py
@@ -257,6 +257,11 @@ class Resource(object):
                 name=urlquote(self.name),
                 partition=self.partition)
             payload = copy.copy(data)
+
+            # removing the mutate read-only attribute 'ipAddress' while updating the ARP
+            if self.classname() == "ApiArp":
+                payload.pop("ipAddress")
+
             if modify:
                 obj.modify(**payload)
             else:


### PR DESCRIPTION
Problem: CIS was unable to update the ARP entries on big ip when there is Mac address update instead of IP address.
Solution: Added a condition to remove the ipaddress field from payload when ever updating the ARP, as it's an immutable field.