### PR TITLE
Updating packages for CVEs

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -27,7 +27,7 @@ enum34==1.1.6
 cryptography==3.3.2
 idna==2.7
 pycparser==2.19
-urllib3==1.24.2
+urllib3==1.26.5
 six==1.15.0
 attrs==18.2.0
 cffi==1.12.2


### PR DESCRIPTION
Updating the packages to remove [CVE-2021-33503](https://github.com/advisories/GHSA-q2q7-5pp4-w6pg)