### PR TITLE
urllib3 package update to 2.6.0 version

### DIFF
--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -16,7 +16,7 @@ chardet==3.0.4
 enum34==1.1.6
 idna==3.7
 pycparser==2.19
-urllib3==2.5.0
+urllib3==2.6.0
 six==1.12.0
 attrs==18.2.0
 cffi==1.15.0


### PR DESCRIPTION
Urllib3 package upgrade for below CVE fixes 

CVE-2025-66418

CVE-2025-66471